### PR TITLE
build: use -lnetsnmp not -lsnmp (TOSS-2815)

### DIFF
--- a/config/ac_snmppower.m4
+++ b/config/ac_snmppower.m4
@@ -11,7 +11,7 @@ AC_DEFUN([AC_SNMPPOWER],
     AC_HELP_STRING([--with-snmppower], [Build snmppower executable]))
   AS_IF([test "x$with_snmppower" = "xyes"], [
     AC_CHECK_HEADERS([net-snmp/net-snmp-config.h])
-    X_AC_CHECK_COND_LIB([snmp], [init_snmp])
+    X_AC_CHECK_COND_LIB([netsnmp], [init_snmp])
   ])
   AS_IF([test "x$with_snmppower" = "xyes" && test "x$ac_cv_header_net_snmp_net_snmp_config_h" = "xno" -o "x$ac_cv_lib_snmp_init_snmp" = "xno"], [
     AC_MSG_ERROR([could not find snmp library])

--- a/snmppower/Makefile.am
+++ b/snmppower/Makefile.am
@@ -5,4 +5,4 @@ AM_CPPFLAGS = -I$(top_srcdir)/libcommon
 sbin_PROGRAMS = snmppower
 
 snmppower_SOURCES = snmppower.c
-snmppower_LDADD = $(top_builddir)/libcommon/libcommon.a $(LIBSNMP) $(LIBFORKPTY)
+snmppower_LDADD = $(top_builddir)/libcommon/libcommon.a $(LIBNETSNMP) $(LIBFORKPTY)


### PR DESCRIPTION
libsnmp goes away in RHEL7.  It turns out libnetsnmp was there in RHEL6.
Presumably we've been linking against a deprecated library name since
the days when the netsnmp project changed its name.

Thanks to bacaldwell for providing this fix back in Jan 28 2015.