### PR TITLE
pkgconfig is required for configure to detect systemd is installed, add as BuildRequire

### DIFF
--- a/powerman.spec.in
+++ b/powerman.spec.in
@@ -13,8 +13,8 @@ BuildRequires: tcp_wrappers-devel
 BuildRequires: genders
 BuildRequires: curl-devel
 BuildRequires: net-snmp-devel
-BuildRequires: systemd
 BuildRequires: pkgconfig
+BuildRequires: pkgconfig(systemd)
 
 %package devel
 Requires: %{name} = %{version}-%{release}

--- a/powerman.spec.in
+++ b/powerman.spec.in
@@ -14,6 +14,7 @@ BuildRequires: genders
 BuildRequires: curl-devel
 BuildRequires: net-snmp-devel
 BuildRequires: systemd
+BuildRequires: pkgconfig
 
 %package devel
 Requires: %{name} = %{version}-%{release}


### PR DESCRIPTION
OBS with SLES builds doesn't include pkgconfig unless explicitly required by the package. The configure script uses pkgconfig to detect if systemd is present if its not explicitly called out.

Added the BuildRequire for pkgconfig, though I see pkgconfig files for powerman are included -- not sure if a straight Require would be better.

SLES calls the pkgconfig package "pkg-config" but both Provide "pkgconfig"