### PR TITLE
portability issues for EL 7.2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,4 +25,4 @@ install-data-local:
 	-$(top_srcdir)/config/install-sh -o $(RUN_AS_USER) -m 755 -d \
 		$(DESTDIR)$(localstatedir)/run/powerman
 
-EXTRA_DIST = DISCLAIMER powerman.spec
+EXTRA_DIST = DISCLAIMER examples/powerman_el72.spec

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ AC_CONFIG_FILES( \
   etc/Makefile \
   scripts/Makefile \
   scripts/powerman \
+  scripts/tmpfiles.d/powerman.conf \
   heartbeat/Makefile \
   man/Makefile \
   man/powerman.1 \

--- a/configure.ac
+++ b/configure.ac
@@ -98,7 +98,7 @@ AC_RUNAS
 ##
 AC_CONFIG_FILES( \
   Makefile \
-  powerman.spec \
+  examples/powerman_el72.spec \
   libpowerman/Makefile \
   libpowerman/libpowerman.pc \
   liblsd/Makefile \

--- a/examples/powerman_el72.spec.in
+++ b/examples/powerman_el72.spec.in
@@ -10,7 +10,7 @@ Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires: tcp_wrappers-devel
-BuildRequires: genders
+BuildRequires: libgenders-devel
 BuildRequires: curl-devel
 BuildRequires: net-snmp-devel
 BuildRequires: systemd
@@ -113,6 +113,11 @@ if [ -x /sbin/ldconfig ]; then /sbin/ldconfig %{_libdir}; fi
 %{_libdir}/*.so.*
 
 %changelog
+
+* Wed Mar 08 2017 Brian J. Murrell <brian.murrell@intel.com> 2.3.25-1
+- Move the powerman.spec to the examples dir and rename it to
+  powerman_el72.spec to indicate that this spec is just an example
+  that works on EL7.2
 
 * Fri Oct 23 2015 Jim Garlick <garlick.jim@gmail.com> 2.3.24-1
 - Don't package /var/run/powerman; let systemd manage this directory.

--- a/powerman.spec.in
+++ b/powerman.spec.in
@@ -97,6 +97,7 @@ if [ -x /sbin/ldconfig ]; then /sbin/ldconfig %{_libdir}; fi
 %{_mandir}/*8/*
 %{_libdir}/stonith/plugins/external/powerman
 %{_unitdir}/powerman.service
+%{_tmpfilesdir}/powerman.conf
 
 %files devel
 %defattr(-,root,root,0755)

--- a/powermand/parse_lex.l
+++ b/powermand/parse_lex.l
@@ -30,6 +30,7 @@
 #endif
 /* N.B. must define YYSTYPE before including parse_tab.h or type will be int. */
 #define YYSTYPE char *
+extern YYSTYPE yylval;
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,8 +1,10 @@
 if HAVE_SYSTEMD
 systemdsystemunit_SCRIPTS = powerman.service
+systemdtmpdir_ddir = ${prefix}/lib/tmpfiles.d
+systemdtmpdir_d_SCRIPTS = tmpfiles.d/powerman.conf
 else
 initconfdir = $(sysconfdir)/init.d
 initconf_SCRIPTS = powerman
 endif
 
-EXTRA_DIST = powerman.service powerman
+EXTRA_DIST = powerman.service powerman tmpfiles.d/powerman.conf

--- a/scripts/powerman.service
+++ b/scripts/powerman.service
@@ -8,8 +8,6 @@ PrivateTmp=yes
 User=daemon
 Group=daemon
 ExecStart=/usr/sbin/powermand
-RuntimeDirectory=powerman
-RuntimeDirectoryMode=0755
 PIDFile=/var/run/powerman/powermand.pid
 
 [Install]

--- a/scripts/tmpfiles.d/powerman.conf.in
+++ b/scripts/tmpfiles.d/powerman.conf.in
@@ -1,0 +1,1 @@
+d @X_LOCALSTATEDIR@/run/powerman   755 daemon daemon


### PR DESCRIPTION
Systemd older than 233 doesn't support RuntimeDirectory*
directives and the accepted method for such releases is
to include a file in /usr/lib/tmpfiles.d to create the
[/var]/run/powerman directory.