### PR TITLE
package: set SHELL in powerman's environment

### DIFF
--- a/README
+++ b/README
@@ -2,4 +2,3 @@ Powerman provides power management in a data center or compute cluster
 environment.  It performs operations such as power on, power off, and
 power cycle via remote power controller (RPC) devices.
 
-A test

--- a/README
+++ b/README
@@ -1,3 +1,5 @@
 Powerman provides power management in a data center or compute cluster
 environment.  It performs operations such as power on, power off, and
 power cycle via remote power controller (RPC) devices.
+
+A test

--- a/scripts/powerman.service
+++ b/scripts/powerman.service
@@ -3,6 +3,7 @@ Description=PowerMan
 After=syslog.target network.target
 
 [Service]
+Environment=SHELL=/bin/sh
 Type=forking
 PrivateTmp=yes
 User=daemon


### PR DESCRIPTION
Powerman may need to run things to connect to power control devices,
such as an ssh command.  For ssh to operate properly it needs to have
SHELL set to a valid shell in it's environment.