### PR TITLE
Allow configuration of service user and group

### DIFF
--- a/config/ac_runas.m4
+++ b/config/ac_runas.m4
@@ -1,6 +1,7 @@
 AC_DEFUN([AC_RUNAS],
 [
     RUN_AS_USER="daemon"
+    RUN_AS_GROUP="daemon"
     AC_MSG_CHECKING(user to run as)
     AC_ARG_WITH(user,
     AC_HELP_STRING([--with-user=username], [user for powerman daemon (daemon)]),
@@ -16,4 +17,20 @@ AC_DEFUN([AC_RUNAS],
             [Powerman daemon user])
     AC_MSG_RESULT(${RUN_AS_USER})
     AC_SUBST(RUN_AS_USER)
+
+    AC_MSG_CHECKING(group to run as)
+    AC_ARG_WITH(group,
+    AC_HELP_STRING([--with-group=groupname], [group for powerman daemon (daemon)]),
+    [       case "${withval}" in
+            yes|no)
+                    ;;
+            *)
+                    RUN_AS_GROUP="${withval}"
+                    ;;
+            esac],
+    )
+    AC_DEFINE_UNQUOTED(RUN_AS_GROUP, "${RUN_AS_GROUP}",
+            [Powerman daemon group])
+    AC_MSG_RESULT(${RUN_AS_GROUP})
+    AC_SUBST(RUN_AS_GROUP)
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ AC_DEFINE(WITH_LSD_NOMEM_ERROR_FUNC, 1, [Define lsd_fatal_error])
 # whether to install pkg-config file for API
 AC_PKGCONFIG
 
-# what user to run daemon as
+# what user and group to run daemon as
 AC_RUNAS
 
 ##

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ AC_CONFIG_FILES( \
   etc/Makefile \
   scripts/Makefile \
   scripts/powerman \
+  scripts/powerman.service \
   scripts/tmpfiles.d/powerman.conf \
   heartbeat/Makefile \
   man/Makefile \

--- a/scripts/powerman.service.in
+++ b/scripts/powerman.service.in
@@ -5,8 +5,8 @@ After=syslog.target network.target
 [Service]
 Type=forking
 PrivateTmp=yes
-User=daemon
-Group=daemon
+User=@RUN_AS_USER@
+Group=@RUN_AS_GROUP@
 ExecStart=/usr/sbin/powermand
 PIDFile=/var/run/powerman/powermand.pid
 


### PR DESCRIPTION
As much as I would <sarcasm>love</sarcasm> to write another sed script modifying various configuration files during the RPM packaging process, I would much rather allow the ./configure script make the change to these files naturally. We (SUSE) currently package the powerman daemon with these autoconf changes, and they test well.

Please review these changes and let me know what we can do to improve them.