### PR TITLE
Added rancid Cisco PoE control dev file

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -50,6 +50,7 @@ pkgsysconf_DATA = \
 	phantom.dev \
 	plmpower.dev \
 	powerman.dev \
+	rancid-cisco-poe.dev \
 	raritan-px4316.dev \
 	raritan-px5523.dev \
 	sentry_cdu.dev \

--- a/etc/rancid-cisco-poe.dev
+++ b/etc/rancid-cisco-poe.dev
@@ -1,0 +1,62 @@
+#
+# Control POE on Cisco switches via rancid (http://www.shrubbery.net/rancid/)
+#
+#   device "cisco-switch" "rancid-cisco-poe" "/usr/lib/rancid/bin/clogin hostname |&"
+#
+# Plug names are the device interface name:
+#   node "mydevice"		"cisco-switch" "Gi2/0/1"
+#
+# The user running the powerman must have a .cloginrc file in its home directory
+# with an appropriate configuration to allow querying and setting PoE status
+#
+specification "rancid-cisco-poe" {
+	timeout 	10
+
+	script login {
+		expect ".*#"
+	}
+	script logout {
+		send "exit\n"
+	}
+	script status {
+		send "show power inline %s | section (on|off) \n"
+		expect "\r\n([^ ]+) +[^ ]+ +(on|off)"
+		setplugstate $1 $2 off="off" on="on"
+		expect ".*#"
+	}
+	script on {
+		send "conf t\n"
+		expect ".*\\(config\\)#"
+		send "int %s\n"
+		expect ".*\\(config-if\\)#"
+		send "no power inline never\n"
+		expect ".*\\(config-if\\)#"
+		send "end\n"
+		expect ".*#"
+	}
+	script off {
+		send "conf t\n"
+		expect ".*\\(config\\)#"
+		send "int %s\n"
+		expect ".*\\(config-if\\)#"
+		send "power inline never\n"
+		expect ".*\\(config-if\\)#"
+		send "end\n"
+		expect ".*#"
+	}
+	script cycle {
+		send "conf t\n"
+		expect ".*\\(config\\)#"
+		send "int %s\n"
+		expect ".*\\(config-if\\)#"
+		send "power inline never\n"
+		expect ".*\\(config-if\\)#"
+		delay 4
+		send "no power inline never\n"
+		expect ".*\\(config-if\\)#"
+		send "end\n"
+		expect ".*#"
+		send "off %s\n"
+		expect ".*#"
+	}
+}


### PR DESCRIPTION
#27 

I threw together a quick-n-dirty dev file to support using rancid (http://www.shrubbery.net/rancid/) for controlling devices using PoE on Cisco switches. I've needed to power-cycle too many of my cameras and PoE Raspberry Pis, and got tired of doing it by hand!

It's not the most elegant thing I have ever written, but it works for me. This could all be done via. direct ssh/telnet to the Cisco device, but I figured I would let rancid take care of the connection negotiation just to keep it simpler.

It should be straight forward to adapt this for any other managed switch that supports PoE and rancid.