### PR TITLE
Add basic support for openbmc w/ httppower

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,6 +167,7 @@ AC_CONFIG_FILES( \
   test/t54.conf \
   test/t55.conf \
   test/t60.conf \
+  test/t61.conf \
   test/test.conf \
   test/test4.conf \
 )

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -47,6 +47,7 @@ pkgsysconf_DATA = \
 	ipmipower-serial.dev \
 	kvm.dev \
 	kvm-ssh.dev \
+	openbmc.dev \
 	phantom.dev \
 	plmpower.dev \
 	powerman.dev \

--- a/etc/openbmc.dev
+++ b/etc/openbmc.dev
@@ -1,0 +1,65 @@
+# Support for OpenBMC Rest Interface
+#
+# Powerman.conf should look something like this:
+#   include "/etc/powerman/openbmc.dev"
+#   device "openbmc1" "openbmc" "/usr/sbin/httppower -u https://pnode1 -H Content-Type:application/json -c |&"
+#   node "node1" "openbmc1" "pnode1"
+#
+# Tested on IBM 8335-GTW w/ firmware ibm-v2.0-0-r46-0-gbed584c.  Known issues:
+# - openbmc's power on/off returns success before the operation has
+#   been completed on the node.  The operation typically takes 20-25
+#   seconds complete.  To ensure powerman does not return before the
+#   on/off is completed, we add a delay of 30 seconds.
+# - httppower can be configured with only one node, so one httppower
+#   co-process is needed for every openbmc node in a cluster.  This
+#   can present scalability problems at larger scales.
+# - There is no background management of up/down status of openbmc
+#   targets.  At larger scales, when there will almost always be one
+#   node removed for servicing, and unresponsive target will always
+#   lead to powerman to timeout.
+# - A longer term solution is being investigated, see:
+#   https://github.com/chaos/powerman/issues/34.
+#
+specification "openbmc" {
+	timeout 	40
+
+# login uses openbmc default username/password, adjust if necessary
+	script login {
+		expect "httppower> "
+		send "post login {\"data\":[\"root\",\"0penBmc\"]}\n"
+		expect "httppower> "
+	}
+	script logout {
+		send "post logout {\"data\":[]}\n"
+		expect "httppower> "
+		send "quit\n"
+	}
+	script status {
+		send "get xyz/openbmc_project/state/chassis0/attr/CurrentPowerState\n"
+	        expect "xyz.openbmc_project.State.Chassis.PowerState.(On|Off)"
+                setplugstate $1 on="On" off="Off"
+		expect "httppower> "
+	}
+	script on {
+		send "put xyz/openbmc_project/state/host0/attr/RequestedHostTransition {\"data\":\"xyz.openbmc_project.State.Host.Transition.On\"}\n"
+		expect "httppower> "
+                delay 30
+                send "get xyz/openbmc_project/state/chassis0/attr/CurrentPowerState\n"
+	        expect "xyz.openbmc_project.State.Chassis.PowerState.On"
+	}
+# this is a soft power off, hard power off will bring down the bmc
+	script off {
+		send "put xyz/openbmc_project/state/host0/attr/RequestedHostTransition {\"data\":\"xyz.openbmc_project.State.Host.Transition.Off\"}\n"
+		expect "httppower> "
+                delay 30
+                send "get xyz/openbmc_project/state/chassis0/attr/CurrentPowerState\n"
+	        expect "xyz.openbmc_project.State.Chassis.PowerState.Off"
+	}
+	script cycle {
+		send "put xyz/openbmc_project/state/host0/attr/RequestedHostTransition {\"data\":\"xyz.openbmc_project.State.Host.Transition.Reboot\"}\n"
+		expect "httppower> "
+                delay 30
+                send "get xyz/openbmc_project/state/chassis0/attr/CurrentPowerState\n"
+	        expect "xyz.openbmc_project.State.Chassis.PowerState.On"
+	}
+}

--- a/httppower/httppower.c
+++ b/httppower/httppower.c
@@ -338,6 +338,10 @@ main(int argc, char *argv[])
     curl_easy_setopt(h, CURLOPT_ERRORBUFFER, errbuf);
     curl_easy_setopt(h, CURLOPT_FAILONERROR, 1);
 
+    /* for time being */
+    curl_easy_setopt(h, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(h, CURLOPT_SSL_VERIFYHOST, 0L);
+
     if (header) {
         header_list = curl_slist_append(header_list, header);
         curl_easy_setopt(h, CURLOPT_HTTPHEADER, header_list);

--- a/httppower/httppower.c
+++ b/httppower/httppower.c
@@ -93,6 +93,7 @@ void post(CURL *h, char **av)
     }
 
     if (postdata && myurl) {
+        curl_easy_setopt(h, CURLOPT_POST, 1);
         curl_easy_setopt(h, CURLOPT_URL, url_ptr);
         curl_easy_setopt(h, CURLOPT_POSTFIELDS, postdata);
         if (curl_easy_perform(h) != 0)
@@ -113,6 +114,7 @@ void get(CURL *h, char **av)
     char *myurl = _make_url(av[0]);
 
     if (myurl) {
+        curl_easy_setopt(h, CURLOPT_HTTPGET, 1);
         curl_easy_setopt(h, CURLOPT_URL, myurl);
         if (curl_easy_perform(h) != 0)
             printf("Error: %s\n", errbuf);

--- a/httppower/httppower.c
+++ b/httppower/httppower.c
@@ -61,7 +61,7 @@ void help(void)
     printf("  seturl url\n");
     printf("  setheader string\n");
     printf("  get [url]\n");
-    printf("  post [url] key=val[&key=val]...\n");
+    printf("  post [url] <string data>\n");
 }
 
 char *

--- a/httppower/httppower.c
+++ b/httppower/httppower.c
@@ -45,14 +45,16 @@ static char *url = NULL;
 static char *header = NULL;
 static struct curl_slist *header_list = NULL;
 static int cookies = 0;
+static int verbose = 0;
 static char *userpwd = NULL;
 static char errbuf[CURL_ERROR_SIZE];
 
-#define OPTIONS "u:H:c"
+#define OPTIONS "u:H:cv"
 static struct option longopts[] = {
         {"url", required_argument, 0, 'u' },
         {"header", required_argument, 0, 'H' },
         {"cookies", no_argument, 0, 'c' },
+        {"verbose", no_argument, 0, 'v' },
         {0,0,0,0},
 };
 
@@ -321,6 +323,9 @@ main(int argc, char *argv[])
 	    case 'c': /* --cookies */
 	        cookies = 1;
 	        break;
+            case 'v': /* --verbose */
+                verbose = 1;
+                break;
             default:
                 usage();
                 break;
@@ -341,6 +346,9 @@ main(int argc, char *argv[])
     /* for time being */
     curl_easy_setopt(h, CURLOPT_SSL_VERIFYPEER, 0L);
     curl_easy_setopt(h, CURLOPT_SSL_VERIFYHOST, 0L);
+
+    if (verbose)
+        curl_easy_setopt(h, CURLOPT_VERBOSE, 1L);
 
     if (header) {
         header_list = curl_slist_append(header_list, header);

--- a/man/httppower.8.in
+++ b/man/httppower.8.in
@@ -35,9 +35,11 @@ Set extra HEADER to use.  Do not specify data to clear.  Overrides the command l
 .I "get [URL-suffix]"
 Send an HTTP GET to the base URL with the optional URL-suffix appended.
 .TP
-.I "post [URL-suffix] key=val[&key=val]..."
-Send an HTTP POST to the base URL with the optional URL-suffix appended,
-and key-value pairs as argument.
+.I "post [URL-suffix] <string data>"
+Send an HTTP POST to the base URL with the optional URL-suffix
+appended, and string data as argument.  Typically, the data is
+key=value pairs (multiple of which can be concatenated with the
+&-symbol), but there can be exceptions.
 
 .SH "FILES"
 @X_SBINDIR@/httppower

--- a/man/httppower.8.in
+++ b/man/httppower.8.in
@@ -40,6 +40,10 @@ Send an HTTP POST to the base URL with the optional URL-suffix
 appended, and string data as argument.  Typically, the data is
 key=value pairs (multiple of which can be concatenated with the
 &-symbol), but there can be exceptions.
+.TP
+.I "put [URL-suffix] <string data>"
+Send an HTTP PUT to the base URL with the optional URL-suffix
+appended, and string data as argument.
 
 .SH "FILES"
 @X_SBINDIR@/httppower

--- a/man/httppower.8.in
+++ b/man/httppower.8.in
@@ -18,6 +18,9 @@ Set the base URL.
 .TP
 .I "-H, --header string"
 Set extra HEADER to use.
+.TP
+.I "-c, --cookies"
+Enable cookies in session.
 .SH INTERACTIVE COMMANDS
 The following commands are accepted at the httppower> prompt:
 .TP
@@ -31,6 +34,9 @@ Set the base URL.  Overrides the command line option.
 .TP
 .I "setheader [string data]"
 Set extra HEADER to use.  Do not specify data to clear.  Overrides the command line option.
+.TP
+.I "cookies <enable|disable>"
+Enable or disable use of cookies.  Overrides the command line option.
 .TP
 .I "get [URL-suffix]"
 Send an HTTP GET to the base URL with the optional URL-suffix appended.

--- a/man/httppower.8.in
+++ b/man/httppower.8.in
@@ -15,6 +15,9 @@ It is run interactively by the powerman daemon.
 .TP
 .I "-u, --url URL"
 Set the base URL.
+.TP
+.I "-H, --header string"
+Set extra HEADER to use.
 .SH INTERACTIVE COMMANDS
 The following commands are accepted at the httppower> prompt:
 .TP
@@ -25,6 +28,9 @@ over the network in plain text.
 .TP
 .I "seturl URL"
 Set the base URL.  Overrides the command line option.
+.TP
+.I "setheader [string data]"
+Set extra HEADER to use.  Do not specify data to clear.  Overrides the command line option.
 .TP
 .I "get [URL-suffix]"
 Send an HTTP GET to the base URL with the optional URL-suffix appended.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,7 +14,8 @@ check_PROGRAMS = \
 	cli \
 	ilom \
 	lom \
-	swpdu
+	swpdu \
+	openbmc-httppower
 
 dist_check_SCRIPTS = \
 	pm-sim \
@@ -33,7 +34,7 @@ TESTS = t00 t01 t02 t03 t04 t05 t06 t07 t08 t09 t10 t11 t12 t13 \
 	t14 t15 t16 t17 t18 t19 t20 t21 t22 t23 t24 t25 t26 t27 \
 	t28 t29 t30 t31 t32 t33 t34 t35 t36 t37 t38 t39 t40 t41 \
 	t42 t43 t44 t45 t46 t47 t48 t49 t50 t51 t52 t53 t54 t55 \
-	t56 t57 t58 t59 t60
+	t56 t57 t58 t59 t60 t61
 
 XFAIL_TESTS = 
 
@@ -93,6 +94,9 @@ cyclades_LDADD = $(common_ldadd)
 ipmipower_SOURCES = ipmipower.c
 ipmipower_LDADD = $(common_ldadd)
 
+openbmc_httppower_SOURCES = openbmc-httppower.c
+openbmc_httppower_LDADD = $(common_ldadd)
+
 cli_SOURCES = cli.c
 cli_LDADD = -L$(top_builddir)/libpowerman -lpowerman
 
@@ -104,7 +108,7 @@ check_DATA = \
 	t35.conf t36.conf t37.conf t38.conf t39.conf t40.conf t41.conf \
 	t42.conf t43.conf t44.conf t45.conf t46.conf t47.conf t48.conf \
 	t49.conf t50.conf t51.conf t53.conf t54.conf t55.conf t60.conf \
-	test4.conf test.conf
+	t61.conf test4.conf test.conf
 
 EXTRA_DIST = $(TESTS:%=%.exp) t53.dev
 

--- a/test/README
+++ b/test/README
@@ -114,3 +114,5 @@ t50
 	Test bashfun demo script.
 t51
 	Test Sun LOM using lom.c
+t61
+        Test httppower openbmc using openbmc-httppower.c

--- a/test/dli.c
+++ b/test/dli.c
@@ -22,7 +22,7 @@
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 \*****************************************************************************/
 
-/* dli.c - mimic httpposer talking to a Digital Loggers Inc LPC */
+/* dli.c - mimic httppower talking to a Digital Loggers Inc LPC */
 
 #include <stdio.h>
 #include <string.h>

--- a/test/openbmc-httppower.c
+++ b/test/openbmc-httppower.c
@@ -1,0 +1,139 @@
+/*****************************************************************************
+ *  Copyright (C) 2004 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Jim Garlick <garlick@llnl.gov>
+ *  UCRL-CODE-2002-008.
+ *
+ *  This file is part of PowerMan, a remote power management program.
+ *  For details, see http://code.google.com/p/powerman/
+ *
+ *  PowerMan is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+\*****************************************************************************/
+
+/* openbmc-httppower.c - mimic httppower talking to a openbmc server */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+#include "xread.h"
+
+static void
+print_unauthenticated (void)
+{
+  printf("{\n"
+         "\"data\": {\n"
+         "\"description\": \"Login required\"\n"
+         "},\n"
+         "\"message\": \"401 Unauthorized\",\n"
+         "\"status\": \"error\"\n"
+         "}\n");
+}
+
+static void
+prompt_loop(void)
+{
+    char buf[1024], urltmp[1024], datatmp[1024];
+    int hoststatus = 0;         /* 0 = off, 1 = on */
+    int authenticated = 0;
+
+    for (;;) {
+        if (xreadline("httppower> ", buf, sizeof(buf)) == NULL)
+            break;
+        if (!strcmp(buf, "help")) {
+            printf("Commands are:\n");
+            printf(" get url data\n");
+            printf(" post url data\n");
+            printf(" put url data\n");
+        } else if (sscanf(buf, "post login %s", datatmp) == 1) {
+            if (!authenticated)
+                authenticated = 1;
+            printf("{\n"
+                   "\"data\": \"User 'root' logged in\",\n"
+                   "\"message\": \"200 OK\",\n"
+                   "\"status\": \"ok\"\n"
+                   "}\n");
+        } else if (sscanf(buf, "post logout %s", datatmp) == 1) {
+            if (authenticated) {
+                authenticated = 0;
+                printf("{\n"
+                       "\"data\": \"User 'root' logged in\",\n"
+                       "\"message\": \"200 OK\",\n"
+                       "\"status\": \"ok\"\n"
+                       "}\n");
+            }
+            else
+                printf("{\n"
+                       "\"data\": \"No user logged in\",\n"
+                       "\"message\": \"200 OK\",\n"
+                       "\"status\": \"ok\"\n"
+                       "}\n");
+        } else if (sscanf(buf, "get %s", urltmp) == 1) {
+            if (!authenticated) {
+                print_unauthenticated ();
+                continue;
+            }
+            if (strstr (urltmp, "CurrentPowerState") == NULL)
+                goto err;
+            printf("{\n"
+                   "\"data\": \"xyz.openbmc_project.State.Chassis.PowerState.%s\",\n"
+                   "\"message\": \"200 OK\",\n"
+                   "\"status\": \"ok\"\n"
+                   "}\n",
+                   hoststatus ? "On" : "Off");
+        } else if (sscanf(buf, "put xyz/openbmc_project/state/host0/attr/RequestedHostTransition %s",
+                          datatmp) == 1) {
+            if (!authenticated) {
+                print_unauthenticated ();
+                continue;
+            }
+            if (strstr (datatmp, "On")) {
+                hoststatus = 1;
+            }
+            else if (strstr (datatmp, "Off")) {
+                hoststatus = 0;
+            }
+            else if (strstr (datatmp, "Reboot")) {
+                if (!hoststatus)
+                    hoststatus = 1;
+            }
+            else
+                goto err;
+            /* Doesn't matter what operation, output success */
+            printf("{\n"
+                   "\"data\": null,\n"
+                   "\"message\": \"200 OK\",\n"
+                   "\"status\": \"ok\"\n"
+                   "}\n");
+        } else
+            goto err;
+
+        continue;
+err:
+        printf("Error\n");
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+    prompt_loop();
+    exit (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/test/t61
+++ b/test/t61
@@ -1,0 +1,10 @@
+#!/bin/sh
+TEST=t61
+$PATH_POWERMAN -Y -S $PATH_POWERMAND -C ${TEST_BUILDDIR}/$TEST.conf \
+    -q -1 t[0-4] \
+    -q -0 t[0-4] \
+    -q -c t[0-4] \
+    -q -0 t[0-4] \
+    -q >$TEST.out 2>$TEST.err
+test $? = 0 || exit 1
+diff $TEST.out ${TEST_SRCDIR}/$TEST.exp >$TEST.diff

--- a/test/t61.conf.in
+++ b/test/t61.conf.in
@@ -1,0 +1,13 @@
+include "@top_srcdir@/etc/openbmc.dev"
+
+device "b0" "openbmc" "@top_builddir@/test/openbmc-httppower |&"
+device "b1" "openbmc" "@top_builddir@/test/openbmc-httppower |&"
+device "b2" "openbmc" "@top_builddir@/test/openbmc-httppower |&"
+device "b3" "openbmc" "@top_builddir@/test/openbmc-httppower |&"
+device "b4" "openbmc" "@top_builddir@/test/openbmc-httppower |&"
+
+node "t0" "b0" "t0"
+node "t1" "b1" "t1"
+node "t2" "b2" "t2"
+node "t3" "b3" "t3"
+node "t4" "b4" "t4"

--- a/test/t61.exp
+++ b/test/t61.exp
@@ -1,0 +1,19 @@
+on:      
+off:     t[0-4]
+unknown: 
+Command completed successfully
+on:      t[0-4]
+off:     
+unknown: 
+Command completed successfully
+on:      
+off:     t[0-4]
+unknown: 
+Command completed successfully
+on:      t[0-4]
+off:     
+unknown: 
+Command completed successfully
+on:      
+off:     t[0-4]
+unknown: 


### PR DESCRIPTION
This is a very simple support of openbmc with httppower.  It's supported like this:

```
include "/etc/powerman/openbmc.dev"

device "openbmc0" "openbmc" "httppower -u https://pnode0 -H Content-Type:application/json -c |&"
device "openbmc1" "openbmc" "httppower -u https://pnode1 -H Content-Type:application/json -c |&"
device "openbmc2" "openbmc" "httppower -u https://pnode2 -H Content-Type:application/json -c |&"
device "openbmc3" "openbmc" "httppower -u https://pnode3 -H Content-Type:application/json -c |&"
device "openbmc4" "openbmc" "httppower -u https://pnode4 -H Content-Type:application/json -c |&"

node "node0" "openbmc0" "pnode0"
node "node1" "openbmc1" "pnode1"
node "node2" "openbmc2" "pnode2"
node "node3" "openbmc3" "pnode3"
node "node4" "openbmc4" "pnode4"
```

While working on this, I realized that scalable and good support of openbmc will be a lot harder / time consuming than originally thought.

- httppower was originally written with a single / "global" curl handle.  Therefore httppower can't be configured to work with multiple hosts if cookies are involved (since they are per host and
  per handle).  Thus the one line per host above.

  To solve this, httppower would have to be written with some type of hashing algorithm to have a curl handle per host and would parse the host off the url used.

- httppower uses the "easy" curl interface, which (AFAICT) is synchronous communication.  Using the "hard" curl interface would allow for parallel network transactions.

- Similar to how ipmi works, an "on" or "off" request / response is independent of the actual action.  So you can get circumstances like this:

```
> powerman --off FOO
Command completed successfully

> powerman -q
on:     FOO
off:
unknown: 
```

  The reason FOO is listed as on, is b/c the http response for "off" has been received, but the "off" action has not yet been done. openbmc can perform the "off" action at some point in the future.

  In ipmipower, this is solved with options like ```--wait-until-on``` and ```--wait-until-off```, which poll until an action is done.

- httppower does not have any ability to determine if a network interface is down.  If powerman were configured for a large number of nodes, we can expect a single node to always be removed for servicing once in awhile.  That means that powerman / httppower will constantly time out on pretty much any action such as ```powerman --query```.

  This was solved in ipmipower b/c ipmipower performs some ipmi "pings" in the background, to effectively monitor for nodes disappearing from the network.

- It's worth noting that the last two points are more difficult than in ipmipower, b/c httppower has no concept of "power query" or "ping".  Those are things defined in the .dev file for every device that uses http.  Does this mean it has to be developed into powerman as a feature for all possible devices?

- Possible option: develop a "openbmcpower" similar to "ipmipower"?
- Possible option: redo "httppower" from scratch to do a lot more stuff.  Future consideration for other rest APIs such as Redfish.