### PR TITLE
log state changes to syslog

### DIFF
--- a/TODO
+++ b/TODO
@@ -48,8 +48,6 @@
   and 2) not always cleaning up properly.  Consider providing a "native"
   sshpower tool using one of the ssh libs. [Jim Garlick]
 
-* Optionally log plug state changes to syslog (or conman?) [Jim Garlick]
-
 * Allow pm -q 'rpc name' and report all pugs (even if not mapped) [Jim Garlick]
 
 * Implement power (watt) monitoring.  Convert units.  When querying by rpc

--- a/etc/powerman.conf.example
+++ b/etc/powerman.conf.example
@@ -6,6 +6,10 @@
 # Uncomment to listen on all ports (default is 127.0.0.1:10101)
 #listen "0.0.0.0:10101"
 
+# Uncomment to set syslog level for power on/off/reset/cycle requests
+# (default is debug). Accepts the same level strings as logger(1).
+#plug_log_level "info"
+
 # Include device specifications for power controllers
 #include "/etc/powerman/apc7900.dev"
 #include "/etc/powerman/apc.dev"

--- a/man/powerman.conf.5.in
+++ b/man/powerman.conf.5.in
@@ -38,6 +38,10 @@ tcpwrappers yes                      # enable TCP wrappers
 
 # listen "0.0.0.0:10101"             # uncomment to listen on all interfaces
 
+# plug_log_level "info"              # uncomment to change syslog messages
+                                     # for plug state changes to level
+                                     # info (default level is debug)
+
 # Alias example - alias can be used in target specifications
 alias "pengra_service" "pengra[0-1]"
 alias "pengra_compute" "pengra[2-15]"

--- a/powermand/client.c
+++ b/powermand/client.c
@@ -662,6 +662,7 @@ static void log_state_change(Client *c)
     char *action = NULL;
     char *hosts;
     char *with_errors = " with errors";
+    int level = conf_get_plug_log_level();
 
     if (c->cmd->com == PM_POWER_ON)
         action = "powered on";
@@ -676,7 +677,7 @@ static void log_state_change(Client *c)
         return;
 
     hosts = _xhostlist_ranged_string(c->cmd->hl);
-    syslog(LOG_DEBUG, "%s %s%s", action, hosts,
+    syslog(level, "%s %s%s", action, hosts,
         (c->cmd->error == TRUE ? with_errors : ""));
     xfree(hosts);
 }

--- a/powermand/client.c
+++ b/powermand/client.c
@@ -657,6 +657,30 @@ static void _telemetry_printf(int client_id, const char *fmt, ...)
     }
 }
 
+static void log_state_change(Client *c)
+{
+    char *action = NULL;
+    char *hosts;
+    char *with_errors = " with errors";
+
+    if (c->cmd->com == PM_POWER_ON)
+        action = "powered on";
+    if (c->cmd->com == PM_POWER_OFF)
+        action = "powered off";
+    if (c->cmd->com == PM_POWER_CYCLE)
+        action = "power cycled";
+    if (c->cmd->com == PM_RESET)
+        action = "reset";
+
+    if (!action)
+        return;
+
+    hosts = _xhostlist_ranged_string(c->cmd->hl);
+    syslog(LOG_DEBUG, "%s %s%s", action, hosts,
+        (c->cmd->error == TRUE ? with_errors : ""));
+    xfree(hosts);
+}
+
 /*
  * Callback for device action completion.
  */
@@ -685,6 +709,8 @@ static void _act_finish(int client_id, ActError acterr, const char *fmt, ...)
 
     /* all actions have called back - return response to client */
     if (--c->cmd->pending == 0) {
+        log_state_change(c);
+
         switch (c->cmd->com) {
         case PM_STATUS_PLUGS:      /* status */
         case PM_STATUS_BEACON:     /* beacon */

--- a/powermand/parse_lex.l
+++ b/powermand/parse_lex.l
@@ -147,6 +147,7 @@ static List line_ptrs;
 
 listen          return TOK_LISTEN;
 tcpwrappers     return TOK_TCP_WRAPPERS;
+plug_log_level  return TOK_PLUG_LOG_LEVEL;
 timeout         return TOK_DEV_TIMEOUT;
 pingperiod      return TOK_PING_PERIOD;
 specification   return TOK_SPEC;

--- a/powermand/parse_tab.y
+++ b/powermand/parse_tab.y
@@ -141,7 +141,7 @@ static Spec current_spec;             /* Holds a Spec as it is built */
 %token TOK_PLUG_NAME TOK_SCRIPT 
 
 /* powerman.conf stuff */
-%token TOK_DEVICE TOK_NODE TOK_ALIAS TOK_TCP_WRAPPERS TOK_LISTEN
+%token TOK_DEVICE TOK_NODE TOK_ALIAS TOK_TCP_WRAPPERS TOK_LISTEN TOK_PLUG_LOG_LEVEL 
 
 /* general */
 %token TOK_MATCHPOS TOK_STRING_VAL TOK_NUMERIC_VAL TOK_YES TOK_NO
@@ -162,6 +162,7 @@ config_list     : config_list config_item
 ;
 config_item     : listen
                 | TCP_wrappers 
+                | plug_log_level
                 | device
                 | node
                 | alias
@@ -174,6 +175,10 @@ TCP_wrappers    : TOK_TCP_WRAPPERS         {
     conf_set_use_tcp_wrappers(TRUE);
 }               | TOK_TCP_WRAPPERS TOK_NO  { 
     conf_set_use_tcp_wrappers(FALSE);
+}
+;
+plug_log_level          : TOK_PLUG_LOG_LEVEL TOK_STRING_VAL { 
+    conf_set_plug_log_level($2);
 }
 ;
 listen          : TOK_LISTEN TOK_STRING_VAL { 

--- a/powermand/parse_util.h
+++ b/powermand/parse_util.h
@@ -11,6 +11,9 @@ hostlist_t conf_getnodes(void);
 bool conf_get_use_tcp_wrappers(void);
 void conf_set_use_tcp_wrappers(bool val);
 
+int conf_get_plug_log_level(void);
+void conf_set_plug_log_level(char *level);
+
 List conf_get_listen(void);
 void conf_add_listen(char *hostport);
 


### PR DESCRIPTION
Introduce a new optional config file parameter, "log_on_off", a string
which specifies a syslog facility.priority pair as used with the
"logger" utility.

If log_on_off is set, node state changes (on/off/cycle/reset) are logged to syslog
using the specified facility.priority.

Fixes #29