### PR TITLE
build: don't install systemd unit file outside of prefix

### DIFF
--- a/config/systemd.m4
+++ b/config/systemd.m4
@@ -33,7 +33,7 @@ AC_DEFUN([RRA_WITH_SYSTEMD_UNITDIR],
     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
         [Directory for systemd service files])],
     [],
-    [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+    [with_systemdsystemunitdir=\${prefix}$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
  AS_IF([test x"$with_systemdsystemunitdir" != xno],
     [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
  AM_CONDITIONAL([HAVE_SYSTEMD],


### PR DESCRIPTION
As noted in #37, travis-ci seems to be broken, failing on the `distcheck` target.
I'm not sure if this ever worked or what, but the systemd m4 macro is the same one we used in flux-core, and over there we fixed a bug that seems applicable here, so pull it in.