### PR TITLE
add redfish support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,7 @@ AC_CONFIG_FILES( \
   test/t55.conf \
   test/t60.conf \
   test/t61.conf \
+  test/t62.conf \
   test/test.conf \
   test/test4.conf \
 )

--- a/etc/redfish.dev
+++ b/etc/redfish.dev
@@ -1,0 +1,68 @@
+# Support for Redfish Rest Interface
+#
+# Powerman.conf should look something like this:
+#   include "/etc/powerman/redfish.dev"
+#   device "redfish1" "redfish" "/usr/sbin/httppower -u https://pnode1 -H Content-Type:application/json |&"
+#   node "node1" "redfish1" "pnode1"
+#
+# - Set your system's username/password in the login section below
+# - There is a chance the URIs below will not work on your system, as
+#   the exact path is not defined and may technically be different.
+#   Please adjust as needed.  Some simple curl commands can be used to
+#   discover the path, such as:
+#
+#   curl -s -u USER:PASS -k -X GET https://pnode1/redfish/v1/Systems/1
+#
+# Tested on Supermicro H12DSG-O-CPU.  Known issues:
+# - redfish's power on/off can return success before the operation has
+#   been completed on the node.  To ensure powerman does not return
+#   before the on/off is completed, we add a delay of 30 seconds.
+# - httppower can be configured with only one node, so one httppower
+#   co-process is needed for every redfish node in a cluster.  This
+#   can present scalability problems at larger scales.
+# - There is no background management of up/down status of redfish
+#   targets.  At larger scales, when there will almost always be one
+#   node removed for servicing, and unresponsive target will always
+#   lead to powerman to timeout.
+# - A longer term solution is being investigated, see:
+#   https://github.com/chaos/powerman/issues/34.
+#
+specification "redfish" {
+	timeout 	40
+
+	script login {
+		expect "httppower> "
+		send "auth USER:PASS\n"
+		expect "httppower> "
+	}
+	script logout {
+		send "quit\n"
+	}
+	script status {
+		send "get redfish/v1/Systems/1/\n"
+	        expect "\"PowerState\":\"(On|Off)\""
+                setplugstate $1 on="On" off="Off"
+		expect "httppower> "
+	}
+	script on {
+		send "post redfish/v1/Systems/1/Actions/ComputerSystem.Reset {\"ResetType\":\"On\"}\n"
+		expect "httppower> "
+                delay 30
+                send "get redfish/v1/Systems/1/\n"
+	        expect "\"PowerState\":\"On\""
+	}
+	script off {
+		send "post redfish/v1/Systems/1/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "httppower> "
+                delay 30
+                send "get redfish/v1/Systems/1/\n"
+	        expect "\"PowerState\":\"Off\""
+	}
+	script cycle {
+		send "post redfish/v1/Systems/1/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "httppower> "
+                delay 30
+                send "get redfish/v1/Systems/1/\n"
+	        expect "\"PowerState\":\"On\""
+	}
+}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,7 +15,8 @@ check_PROGRAMS = \
 	ilom \
 	lom \
 	swpdu \
-	openbmc-httppower
+	openbmc-httppower \
+	redfish-httppower
 
 dist_check_SCRIPTS = \
 	pm-sim \
@@ -34,7 +35,7 @@ TESTS = t00 t01 t02 t03 t04 t05 t06 t07 t08 t09 t10 t11 t12 t13 \
 	t14 t15 t16 t17 t18 t19 t20 t21 t22 t23 t24 t25 t26 t27 \
 	t28 t29 t30 t31 t32 t33 t34 t35 t36 t37 t38 t39 t40 t41 \
 	t42 t43 t44 t45 t46 t47 t48 t49 t50 t51 t52 t53 t54 t55 \
-	t56 t57 t58 t59 t60 t61
+	t56 t57 t58 t59 t60 t61 t62
 
 XFAIL_TESTS = 
 
@@ -96,6 +97,9 @@ ipmipower_LDADD = $(common_ldadd)
 
 openbmc_httppower_SOURCES = openbmc-httppower.c
 openbmc_httppower_LDADD = $(common_ldadd)
+
+redfish_httppower_SOURCES = redfish-httppower.c
+redfish_httppower_LDADD = $(common_ldadd)
 
 cli_SOURCES = cli.c
 cli_LDADD = -L$(top_builddir)/libpowerman -lpowerman

--- a/test/redfish-httppower.c
+++ b/test/redfish-httppower.c
@@ -1,0 +1,94 @@
+/*****************************************************************************
+ *  Copyright (C) 2021 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Albert Chu <chu11@llnl.gov>
+ *  UCRL-CODE-2002-008.
+ *
+ *  This file is part of PowerMan, a remote power management program.
+ *  For details, see http://code.google.com/p/powerman/
+ *
+ *  PowerMan is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+\*****************************************************************************/
+
+/* redfish-httppower.c - mimic httppower talking to a redfish server */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+#include "xread.h"
+
+static void
+prompt_loop(void)
+{
+    char buf[1024], urltmp[1024], datatmp[1024];
+    int hoststatus = 0;         /* 0 = off, 1 = on */
+
+    for (;;) {
+        if (xreadline("httppower> ", buf, sizeof(buf)) == NULL)
+            break;
+        if (!strcmp(buf, "help")) {
+            printf("Commands are:\n");
+            printf(" auth user:pass\n");
+            printf(" get url data\n");
+            printf(" post url data\n");
+        } else if (sscanf(buf, "auth %s", datatmp) == 1) {
+            /* we're not authenticating for real, so do nothing */
+        } else if (sscanf(buf, "get %s", urltmp) == 1) {
+            if (strstr (urltmp, "redfish") == NULL)
+                goto err;
+            printf("{\n"
+                   "\"PowerState\":\"%s\",\n"
+                   "}\n",
+                   hoststatus ? "On" : "Off");
+        } else if (sscanf(buf, "put redfish/v1/Systems/1/Actions/ComputerSystem.Reset %s",
+                          datatmp) == 1) {
+            if (strstr (datatmp, "On")) {
+                hoststatus = 1;
+            }
+            else if (strstr (datatmp, "ForceOff")) {
+                hoststatus = 0;
+            }
+            else if (strstr (datatmp, "ForceRestart")) {
+                if (!hoststatus)
+                    hoststatus = 1;
+            }
+            else
+                goto err;
+            /* Doesn't matter what operation, output success */
+            printf("{\n"
+                   "\"PowerState\":\"%s\",\n"
+                   "}\n",
+                   hoststatus ? "On" : "Off");
+        } else
+            goto err;
+
+        continue;
+err:
+        printf("Error\n");
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+    prompt_loop();
+    exit (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/test/t62
+++ b/test/t62
@@ -1,0 +1,10 @@
+#!/bin/sh
+TEST=t61
+$PATH_POWERMAN -Y -S $PATH_POWERMAND -C ${TEST_BUILDDIR}/$TEST.conf \
+    -q -1 t[0-4] \
+    -q -0 t[0-4] \
+    -q -c t[0-4] \
+    -q -0 t[0-4] \
+    -q >$TEST.out 2>$TEST.err
+test $? = 0 || exit 1
+diff $TEST.out ${TEST_SRCDIR}/$TEST.exp >$TEST.diff

--- a/test/t62.conf.in
+++ b/test/t62.conf.in
@@ -1,0 +1,13 @@
+include "@top_srcdir@/etc/redfish.dev"
+
+device "b0" "redfish" "@top_builddir@/test/redfish-httppower |&"
+device "b1" "redfish" "@top_builddir@/test/redfish-httppower |&"
+device "b2" "redfish" "@top_builddir@/test/redfish-httppower |&"
+device "b3" "redfish" "@top_builddir@/test/redfish-httppower |&"
+device "b4" "redfish" "@top_builddir@/test/redfish-httppower |&"
+
+node "t0" "b0" "t0"
+node "t1" "b1" "t1"
+node "t2" "b2" "t2"
+node "t3" "b3" "t3"
+node "t4" "b4" "t4"

--- a/test/t62.exp
+++ b/test/t62.exp
@@ -1,0 +1,19 @@
+on:      
+off:     t[0-4]
+unknown: 
+Command completed successfully
+on:      t[0-4]
+off:     
+unknown: 
+Command completed successfully
+on:      
+off:     t[0-4]
+unknown: 
+Command completed successfully
+on:      t[0-4]
+off:     
+unknown: 
+Command completed successfully
+on:      
+off:     t[0-4]
+unknown: 


### PR DESCRIPTION
This adds basic redfish to powerman, its very similar to the openbmc support that I added previously.  Similar issues that exist with openbmc exist here.