### PR TITLE
ci: add dummy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,8 @@
+name: ci
+
+on: [ workflow_dispatch ]
+
+jobs:
+  dummyjob:
+    steps:
+    - name: dummystep


### PR DESCRIPTION
Problem: empty github workflow failed.

Error : .github#L1
No event triggers defined in `on`

Add a valid, minimal workflow.