### PR TITLE
ci: try again for minimal dummy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,5 +4,6 @@ on: [ workflow_dispatch ]
 
 jobs:
   dummyjob:
+    runs-on: ubuntu-latest
     steps:
-    - name: dummystep
+    - run: /bin/true


### PR DESCRIPTION
Problem: previous attempt at dummy github workflow failed.

Error : .github#L1
every step must define a `uses` or `run` key

Try again with run key defined.