### PR TITLE
require warning-free compilation

### DIFF
--- a/config/ax_compiler_vendor.m4
+++ b/config/ax_compiler_vendor.m4
@@ -1,0 +1,88 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compiler_vendor.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_VENDOR
+#
+# DESCRIPTION
+#
+#   Determine the vendor of the C/C++ compiler, e.g., gnu, intel, ibm, sun,
+#   hp, borland, comeau, dec, cray, kai, lcc, metrowerks, sgi, microsoft,
+#   watcom, etc. The vendor is returned in the cache variable
+#   $ax_cv_c_compiler_vendor for C and $ax_cv_cxx_compiler_vendor for C++.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2008 Matteo Frigo
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 16
+
+AC_DEFUN([AX_COMPILER_VENDOR],
+[AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor,
+  dnl Please add if possible support to ax_compiler_version.m4
+  [# note: don't check for gcc first since some other compilers define __GNUC__
+  vendors="intel:     __ICC,__ECC,__INTEL_COMPILER
+           ibm:       __xlc__,__xlC__,__IBMC__,__IBMCPP__
+           pathscale: __PATHCC__,__PATHSCALE__
+           clang:     __clang__
+           cray:      _CRAYC
+           fujitsu:   __FUJITSU
+           gnu:       __GNUC__
+           sun:       __SUNPRO_C,__SUNPRO_CC
+           hp:        __HP_cc,__HP_aCC
+           dec:       __DECC,__DECCXX,__DECC_VER,__DECCXX_VER
+           borland:   __BORLANDC__,__CODEGEARC__,__TURBOC__
+           comeau:    __COMO__
+           kai:       __KCC
+           lcc:       __LCC__
+           sgi:       __sgi,sgi
+           microsoft: _MSC_VER
+           metrowerks: __MWERKS__
+           watcom:    __WATCOMC__
+           portland:  __PGI
+	   tcc:       __TINYC__
+           unknown:   UNKNOWN"
+  for ventest in $vendors; do
+    case $ventest in
+      *:) vendor=$ventest; continue ;;
+      *)  vencpp="defined("`echo $ventest | sed 's/,/) || defined(/g'`")" ;;
+    esac
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[
+      #if !($vencpp)
+        thisisanerror;
+      #endif
+    ])], [break])
+  done
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor=`echo $vendor | cut -d: -f1`
+ ])
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@
 AC_INIT([powerman],
         m4_esyscmd([git describe --always | awk '/.*/ {printf "%s",$1; exit}']))
 AC_CONFIG_AUX_DIR([config])
+AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS])
 AC_CANONICAL_SYSTEM
 X_AC_EXPAND_INSTALL_DIRS
@@ -14,7 +15,7 @@ X_AC_EXPAND_INSTALL_DIRS
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AM_CONFIG_HEADER([config/config.h])
-AM_MAINTAINER_MODE
+AM_MAINTAINER_MODE([enable])
 
 ##
 # Checks for programs.

--- a/configure.ac
+++ b/configure.ac
@@ -21,10 +21,17 @@ AM_MAINTAINER_MODE([enable])
 # Checks for programs.
 ##
 AC_PROG_CC
-if test "$GCC" = yes; then
-  GCCWARN="-Wall -Werror"
-  AC_SUBST([GCCWARN])
-fi
+AX_COMPILER_VENDOR
+AS_CASE($ax_cv_c_compiler_vendor,
+  [gnu], [
+      WARNING_CFLAGS="-Wall -Werror"
+  ]
+  [clang], [
+      WARNING_CFLAGS="-Wall -Werror -Wno-unknown-warning-option -Wno-error=unknown-warning-option"
+  ]
+)
+AC_SUBST([WARNING_CFLAGS])
+
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AM_PROG_LEX

--- a/configure.ac
+++ b/configure.ac
@@ -22,8 +22,7 @@ AM_MAINTAINER_MODE([enable])
 ##
 AC_PROG_CC
 if test "$GCC" = yes; then
-  #GCCWARN="-Wall -Werror"
-  GCCWARN="-Wall"
+  GCCWARN="-Wall -Werror"
   AC_SUBST([GCCWARN])
 fi
 AC_PROG_LN_S

--- a/httppower/Makefile.am
+++ b/httppower/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_srcdir)/libcommon
 

--- a/libcommon/Makefile.am
+++ b/libcommon/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_srcdir)/liblsd
 

--- a/liblsd/Makefile.am
+++ b/liblsd/Makefile.am
@@ -1,5 +1,5 @@
-AM_CFLAGS = @GCCWARN@
-
+AM_CFLAGS = @GCCWARN@ \
+	-Wno-parentheses -Wno-error=parentheses
 AM_CPPFLAGS =
 
 noinst_LIBRARIES = liblsd.a

--- a/liblsd/Makefile.am
+++ b/liblsd/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@ \
+AM_CFLAGS = @WARNING_CFLAGS@ \
 	-Wno-parentheses -Wno-error=parentheses
 AM_CPPFLAGS =
 

--- a/liblsd/hostlist.c
+++ b/liblsd/hostlist.c
@@ -369,7 +369,7 @@ static char * _next_tok(char *sep, char **str)
     int level = 0;
 
     /* push str past any leading separators */
-    while (**str != '\0' && strchr(sep, **str) != '\0')
+    while (**str != '\0' && strchr(sep, **str) != NULL)
         (*str)++;
 
     if (**str == '\0')
@@ -386,7 +386,7 @@ static char * _next_tok(char *sep, char **str)
     }
     
    /* nullify consecutive separators and push str beyond them */
-    while (**str != '\0' && strchr(sep, **str) != '\0')
+    while (**str != '\0' && strchr(sep, **str) != NULL)
         *(*str)++ = '\0';
 
     return tok;

--- a/liblsd/hostlist.c
+++ b/liblsd/hostlist.c
@@ -1512,7 +1512,7 @@ _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
     }
 
     while ((tok = _next_tok(sep, &str)) != NULL) {
-        strncpy(cur_tok, tok, 1024);
+        strncpy(cur_tok, tok, sizeof (cur_tok) - 1);
 
         if ((p = strchr(tok, '[')) != NULL) {
             char *q, *prefix = tok;

--- a/libpowerman/Makefile.am
+++ b/libpowerman/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_srcdir)/libcommon
 

--- a/plmpower/Makefile.am
+++ b/plmpower/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_srcdir)/libcommon
 

--- a/powerman/Makefile.am
+++ b/powerman/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_srcdir)/liblsd -I$(top_srcdir)/libcommon
 

--- a/powermand/Makefile.am
+++ b/powermand/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_srcdir)/liblsd -I$(top_srcdir)/libcommon
 

--- a/powermand/parse_lex.l
+++ b/powermand/parse_lex.l
@@ -93,16 +93,10 @@ static List line_ptrs;
 
 <lex_str>{ 
     \" {   
-        /* end of string */
-        int len;
-
         BEGIN(INITIAL); 
         *string_buf_ptr = '\0';
-        len = strlen(string_buf);
-        yylval = xmalloc(len + 1);
+        yylval = xstrdup (string_buf);
         list_append(line_ptrs, yylval);
-        strncpy(yylval, string_buf, len);
-        yylval[len] = '\0';
         return TOK_STRING_VAL; 
     }
     "\\a" {

--- a/powermand/parse_lex.l
+++ b/powermand/parse_lex.l
@@ -44,6 +44,7 @@ extern YYSTYPE yylval;
 #include "parse_util.h"
 extern void yyerror();
 
+#define YY_NO_INPUT /* silence compiler warnings about unused input() */
 #define MAX_INCLUDE_DEPTH 10
 static YY_BUFFER_STATE include_stack[MAX_INCLUDE_DEPTH];
 static int linenum[MAX_INCLUDE_DEPTH];

--- a/redfishpower/Makefile.am
+++ b/redfishpower/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/liblsd \

--- a/snmppower/Makefile.am
+++ b/snmppower/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_srcdir)/libcommon
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -41,7 +41,7 @@ XFAIL_TESTS =
 
 CLEANFILES = *.out *.err *.diff
 
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/libcommon \

--- a/test/ilom.c
+++ b/test/ilom.c
@@ -172,7 +172,7 @@ prompt_loop(void)
 {
     char buf[128];
     static char plug[4];
-    int authenticated;
+    int authenticated = 0;
 
     strcpy(plug, "Off");
     switch (personality) {

--- a/test/lom.c
+++ b/test/lom.c
@@ -115,7 +115,7 @@ prompt_loop(void)
 {
     char buf[128];
     static char plug[4];
-    int authenticated;
+    int authenticated = 0;
 
     strcpy(plug, "Off");
     switch (personality) {

--- a/test/vpcd.c
+++ b/test/vpcd.c
@@ -273,7 +273,7 @@ _prompt_loop(void)
 {
     int seq, i;
     char buf[128];
-    char prompt[16];
+    char prompt[128];
 
     for (seq = 0;; seq++) {
         snprintf(prompt, sizeof(prompt), "%d vpc> ", seq);


### PR DESCRIPTION
This PR fixes all known compiler warnings and re-enables `-Wall -Werror` so we catch future ones in CI.

It also enables automake "maintainer mode", because that's handy.