### PR TITLE
testsuite: fix parallel make failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         cc: [gcc, clang]
-        os: [ubuntu-latest, ubuntu-18.04]
+        os: [ubuntu-latest, ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/test/t49
+++ b/test/t49
@@ -3,19 +3,19 @@ TEST=t49
 
 $PATH_POWERMAND -c ${TEST_BUILDDIR}/$TEST.conf -f -1 2>/dev/null&  
 sleep 1
-./cli localhost:10103 q t1 >$TEST.out 2>$TEST.err
+./cli localhost:10104 q t1 >$TEST.out 2>$TEST.err
 test $? = 0 || exit 1
 wait
 
 $PATH_POWERMAND -c ${TEST_BUILDDIR}/$TEST.conf -f -1 2>/dev/null&  
 sleep 1
-./cli localhost:10103 l >>$TEST.out 2>>$TEST.err
+./cli localhost:10104 l >>$TEST.out 2>>$TEST.err
 test $? = 0 || exit 1
 wait
 
 $PATH_POWERMAND -c ${TEST_BUILDDIR}/$TEST.conf -f -1 2>/dev/null&  
 sleep 1
-./cli localhost:10103 1 t0 >>$TEST.out 2>>$TEST.err
+./cli localhost:10104 1 t0 >>$TEST.out 2>>$TEST.err
 test $? = 0 || exit 1
 wait
 

--- a/test/t49.conf.in
+++ b/test/t49.conf.in
@@ -1,4 +1,4 @@
-listen "0.0.0.0:10103"
+listen "0.0.0.0:10104"
 
 include "@top_srcdir@/etc/vpc.dev"
 device "test0" "vpc" "@top_builddir@/test/vpcd |&"


### PR DESCRIPTION
Problem: tests t48 and t49 use the port 10103 and
will conflict if run at the same time.

Change t49 to use port 10104.

Fixes part of #63