### PR TITLE
Fix misleading-indentation error when running make on RHEL9

### DIFF
--- a/powermand/client.c
+++ b/powermand/client.c
@@ -1067,9 +1067,10 @@ void cli_pre_poll(xpollfd_t pfd)
     int i;
 
     for (i = 0; i < listen_fds_len; i++) {
-        if (listen_fds[i] != NO_FD)
+        if (listen_fds[i] != NO_FD) {
             assert(listen_fds[i] >= 0);
             xpollfd_set(pfd, listen_fds[i], XPOLLIN);
+        }
     }
 
     itr = list_iterator_create(cli_clients);


### PR DESCRIPTION
I encountered a **misleading-indentation** error when running `make` on three separate Rocky Linux 9.1 servers. I guess it _might_ affect el9 in general but I can't confirm. It's an incredibly trivial fix of enclosing the if statement on line 1070 in `powermand/client.c` in curly-braces. The error occurs when trying to build powermand:

**Steps to reproduce:**
```
chmod +x autogen.sh
./autogen.sh
make
```

```
Making all in powermand
make[1]: Entering directory '/home/paisley/powerman/powermand'
  CC       arglist.o
  CC       client.o
client.c: In function ‘cli_pre_poll’:
client.c:1070:9: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
 1070 |         if (listen_fds[i] != NO_FD)
      |         ^~
client.c:1072:13: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
 1072 |             xpollfd_set(pfd, listen_fds[i], XPOLLIN);
      |             ^~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:526: client.o] Error 1
make[1]: Leaving directory '/home/paisley/powerman/powermand'
make: *** [Makefile:467: all-recursive] Error 1
```

**`make` version**
```
make --version
GNU Make 4.3
Built for x86_64-redhat-linux-gnu
```

**OS version**
```
$ cat /etc/*elease
NAME="Rocky Linux"
VERSION="9.1 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.1"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Rocky Linux 9.1 (Blue Onyx)"
CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
ROCKY_SUPPORT_PRODUCT_VERSION="9.1"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.1"
Rocky Linux release 9.1 (Blue Onyx)
```
