### PR TITLE
redfishpower: check for post data

### DIFF
--- a/redfishpower/redfishpower.c
+++ b/redfishpower/redfishpower.c
@@ -426,6 +426,11 @@ static void power_cmd(List activecmds,
         return;
     }
 
+    if (!postdata) {
+        printf("%s postdata not setup\n", cmd);
+        return;
+    }
+
     if (av[0]) {
         if (!(lhosts = parse_input_hosts(av[0])))
             return;


### PR DESCRIPTION
Problem: When issuing a power command, checks are done to ensure paths are setup, but not post data.  If the latter is not set, it can lead to a segfault.

Add check for post data.