### PR TITLE
etc: fix logic error in redfishpower cray windom

### DIFF
--- a/etc/redfishpower-cray-windom.dev
+++ b/etc/redfishpower-cray-windom.dev
@@ -60,9 +60,9 @@ specification "redfishpower-cray-windom-node0" {
 		expect "redfishpower> "
 	}
 	script cycle_ranged {
-		send "on %s\n"
-		expect "redfishpower> "
 		send "off %s\n"
+		expect "redfishpower> "
+		send "on %s\n"
 		expect "redfishpower> "
 	}
 }
@@ -103,9 +103,9 @@ specification "redfishpower-cray-windom-node1" {
 		expect "redfishpower> "
 	}
 	script cycle_ranged {
-		send "on %s\n"
-		expect "redfishpower> "
 		send "off %s\n"
+		expect "redfishpower> "
+		send "on %s\n"
 		expect "redfishpower> "
 	}
 }


### PR DESCRIPTION
Problem: The cycle_ranged logic in redfishpower-cray-windom.dev is backwards, issuing an "on" before an "off".  It should be the other way around.

Solution: Perform an off and then an on for cycle_ranged.

Fixes #69