### PR TITLE
test: fix redfishpower tests

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -112,7 +112,7 @@ check_DATA = \
 	t35.conf t36.conf t37.conf t38.conf t39.conf t40.conf t41.conf \
 	t42.conf t43.conf t44.conf t46.conf t47.conf t48.conf \
 	t49.conf t50.conf t51.conf t53.conf t54.conf t55.conf t60.conf \
-	t61.conf test4.conf test.conf
+	t61.conf t62.conf t63.conf test4.conf test.conf
 
 EXTRA_DIST = $(TESTS:%=%.exp) t53.dev
 

--- a/test/t63.conf.in
+++ b/test/t63.conf.in
@@ -1,3 +1,3 @@
-include "@top_srcdir@/etc/ipmipower.dev"
-device "d0" "ipmipower" "@top_builddir@/test/ipmipower -h t[0-15]|&"
+include "@top_srcdir@/etc/redfishpower-cray-r272z30.dev"
+device "d0" "redfishpower-cray-r272z30" "@top_builddir@/test/redfishpower -h t[0-15]|&"
 node "t[0-15]" "d0"


### PR DESCRIPTION
Problem: redfishpower was inadvertently not tested because the test
configuration copy and pasted "ipmipower" and never changed it.

Update test to use redfishpower instead of ipmipower.