### PR TITLE
WIP: redfisherpower: support tweaks to status polling interval

### DIFF
--- a/etc/devices/redfishpower-cray-r272z30.dev
+++ b/etc/devices/redfishpower-cray-r272z30.dev
@@ -33,6 +33,8 @@ specification "redfishpower-cray-r272z30" {
 		expect "redfishpower> "
 		send "settimeout 60\n"
 		expect "redfishpower> "
+		send "setstatuspollinginterval 1\n"
+		expect "redfishpower> "
 	}
 	script logout {
 		send "quit\n"

--- a/etc/devices/redfishpower-cray-windom.dev
+++ b/etc/devices/redfishpower-cray-windom.dev
@@ -39,6 +39,8 @@ specification "redfishpower-cray-windom-node0" {
 		expect "redfishpower> "
 		send "settimeout 60\n"
 		expect "redfishpower> "
+		send "setstatuspollinginterval 1\n"
+		expect "redfishpower> "
 	}
 	script logout {
 		send "quit\n"
@@ -83,6 +85,8 @@ specification "redfishpower-cray-windom-node1" {
 		send "setoffpath redfish/v1/Systems/Node1/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceOff\"}\n"
 		expect "redfishpower> "
 		send "settimeout 60\n"
+		expect "redfishpower> "
+		send "setstatuspollinginterval 1\n"
 		expect "redfishpower> "
 	}
 	script logout {

--- a/etc/devices/redfishpower-supermicro.dev
+++ b/etc/devices/redfishpower-supermicro.dev
@@ -33,6 +33,8 @@ specification "redfishpower-supermicro" {
 		expect "redfishpower> "
 		send "settimeout 60\n"
 		expect "redfishpower> "
+		send "setstatuspollinginterval 1\n"
+		expect "redfishpower> "
 	}
 	script logout {
 		send "quit\n"

--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -146,7 +146,11 @@ This can sometimes take awhile and on some systems may push the
 timeout limit specified in the device file (typically 60 seconds).  If
 necessary, it should be increased at the top of the specification file
 (via \fItimeout\fR) and the login section of device file (via
-\fIsettimeout\fR).
+\fIsettimeout\fR).  The polling interval that
+.B redfishpower
+uses can be tuned with via \fIsetstatuspollinginterval\fR.  It may be wise
+to tune this when the timeout is large and avoid sending out an excessive
+number of status checks.
 .LP
 Note that if \fIcycle_ranged\fR is scripted as an \fIoff\fR followed by an
 \fIon\fR, the

--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -78,6 +78,10 @@ Set path and optional post data to turn cycle node.
 .I "settimeout <seconds>"
 Set command timeout in seconds.
 .TP
+.I "setstatuspollinginterval <seconds>"
+Set status polling interval in seconds.  This is the polling interval
+to determine an on/off command has completed.
+.TP
 .I "stat [nodes]"
 Get power status of all nodes or specified subset of nodes.
 .TP

--- a/t/simulators/redfishpower.c
+++ b/t/simulators/redfishpower.c
@@ -214,7 +214,8 @@ _prompt_loop(void)
                    || !strcmp(buf, "setonpath")
                    || !strcmp(buf, "setoffpath")
                    || !strcmp(buf, "setcyclepath")
-                   || !strcmp(buf, "settimeout")) {
+                   || !strcmp(buf, "settimeout")
+                   || !strcmp(buf, "setstatuspollinginterval")) {
             /* do nothing with config, just accept */
             ;
         } else if (!strcmp(buf, "stat")) {


### PR DESCRIPTION
Problem: The wait until on/off retry delay in redfishpower is currently hard coded to 1 second.  On some slow systems, it has been observed that on/off can take upwards of a minute.  On that hardware, a 1 second retry delay can lead to an excess amount of traffic on the network.

Support a prompt command that will allow change of the wait until delay time.  Update redfishpower test helper as well.

also add text to all redfishpower device files about update / tweaks if the timeout on their nodes is excessive.

Edit: oh yeah, built on top of #72 