### PR TITLE
build: modernize autoconf, fix bison/flex detection

### DIFF
--- a/config/ac_genders.m4
+++ b/config/ac_genders.m4
@@ -7,7 +7,7 @@
 AC_DEFUN([AC_GENDERS],
 [
   AC_ARG_WITH([genders],
-    AC_HELP_STRING([--with-genders], [Build genders support for client]))
+    AS_HELP_STRING([--with-genders], [Build genders support for client]))
   AS_IF([test "x$with_genders" = "xyes"], [
     AC_CHECK_HEADERS([genders.h])
     X_AC_CHECK_COND_LIB([genders], [genders_handle_create])

--- a/config/ac_httppower.m4
+++ b/config/ac_httppower.m4
@@ -8,7 +8,7 @@
 AC_DEFUN([AC_HTTPPOWER],
 [
   AC_ARG_WITH([httppower],
-    AC_HELP_STRING([--with-httppower], [Build httppower executable]))
+    AS_HELP_STRING([--with-httppower], [Build httppower executable]))
   AS_IF([test "x$with_httppower" = "xyes"], [
     AC_CHECK_HEADERS([curl/curl.h])
     X_AC_CHECK_COND_LIB([curl], [curl_easy_setopt])

--- a/config/ac_pkgconfig.m4
+++ b/config/ac_pkgconfig.m4
@@ -5,7 +5,7 @@ AC_DEFUN([AC_PKGCONFIG],
     pkgconfigdir='${libdir}/pkgconfig'
     AC_MSG_CHECKING(whether to install pkg-config *.pc files)
     AC_ARG_WITH(pkgconfig-dir,
-     AC_HELP_STRING([--with-pkgconfig-dir=PATH], [where to install pkg-config *.pc files (EPREFIX/lib/pkgconfig)]),
+     AS_HELP_STRING([--with-pkgconfig-dir=PATH], [where to install pkg-config *.pc files (EPREFIX/lib/pkgconfig)]),
      [
         case "${withval}" in
             yes|auto)

--- a/config/ac_redfishpower.m4
+++ b/config/ac_redfishpower.m4
@@ -5,7 +5,7 @@
 AC_DEFUN([AC_REDFISHPOWER],
 [
   AC_ARG_WITH([redfishpower],
-    AC_HELP_STRING([--with-redfishpower], [Build redfishpower executable]))
+    AS_HELP_STRING([--with-redfishpower], [Build redfishpower executable]))
   AS_IF([test "x$with_redfishpower" = "xyes"], [
     AC_CHECK_HEADERS([curl/curl.h])
     X_AC_CHECK_COND_LIB([curl], [curl_multi_perform])

--- a/config/ac_runas.m4
+++ b/config/ac_runas.m4
@@ -3,7 +3,7 @@ AC_DEFUN([AC_RUNAS],
     RUN_AS_USER="daemon"
     AC_MSG_CHECKING(user to run as)
     AC_ARG_WITH(user,
-    AC_HELP_STRING([--with-user=username], [user for powerman daemon (daemon)]),
+    AS_HELP_STRING([--with-user=username], [user for powerman daemon (daemon)]),
     [       case "${withval}" in
             yes|no)
                     ;;

--- a/config/ac_snmppower.m4
+++ b/config/ac_snmppower.m4
@@ -8,7 +8,7 @@
 AC_DEFUN([AC_SNMPPOWER],
 [
   AC_ARG_WITH([snmppower],
-    AC_HELP_STRING([--with-snmppower], [Build snmppower executable]))
+    AS_HELP_STRING([--with-snmppower], [Build snmppower executable]))
   AS_IF([test "x$with_snmppower" = "xyes"], [
     AC_CHECK_HEADERS([net-snmp/net-snmp-config.h])
     X_AC_CHECK_COND_LIB([netsnmp], [init_snmp])

--- a/config/ac_wrap.m4
+++ b/config/ac_wrap.m4
@@ -8,7 +8,7 @@
 AC_DEFUN([AC_WRAP],
 [
   AC_ARG_WITH([tcp-wrappers],
-    AC_HELP_STRING([--with-tcp-wrappers], [Build with tcp wrappers support]))
+    AS_HELP_STRING([--with-tcp-wrappers], [Build with tcp wrappers support]))
   AS_IF([test "x$with_tcp_wrappers" = "xyes"], [
     AC_CHECK_HEADERS([tcpd.h])
     X_AC_CHECK_COND_LIB([wrap], [hosts_ctl])

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,11 @@ AC_SUBST([WARNING_CFLAGS])
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_LEX([noyywrap])
+AS_IF([test "x$LEX" = "x:"],AC_MSG_ERROR([could not find flex]),[])
 AC_PROG_YACC
+# AC_PROG_YACC sets YACC=yacc when nothing is found, even yacc
+# Just assume bison is the preferred compiler-compiler and call yacc a failure
+AS_IF([test "x$YACC" = "xyacc"],AC_MSG_ERROR([could not find bison]),[])
 AM_CONDITIONAL(WITH_GNU_LD, test "$with_gnu_ld" = "yes")
 
 ##

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,9 @@ AC_INIT([powerman],
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS])
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_TARGET
+
+LT_INIT
 
 ##
 # If runstatedir not explicitly set on command line, use '/run' as default
@@ -22,7 +24,7 @@ X_AC_EXPAND_INSTALL_DIRS
 ##
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
-AM_CONFIG_HEADER([config/config.h])
+AC_CONFIG_HEADERS([config/config.h])
 AM_MAINTAINER_MODE([enable])
 
 ##
@@ -42,9 +44,8 @@ AC_SUBST([WARNING_CFLAGS])
 
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
-AM_PROG_LEX
+AC_PROG_LEX([noyywrap])
 AC_PROG_YACC
-AC_PROG_LIBTOOL
 AM_CONDITIONAL(WITH_GNU_LD, test "$with_gnu_ld" = "yes")
 
 ##
@@ -56,7 +57,6 @@ AC_CHECK_FILES(/dev/ptc)
 ##
 # Checks for header files.
 ##
-AC_HEADER_STDC
 AC_CHECK_HEADERS( \
   getopt.h \
   poll.h \


### PR DESCRIPTION
Problem: newer autotools warns of obsolete macros and doesn't abort if required bison/flex are not found.

Fix those two things.