### PR TITLE
.mergify.yml: Add mergify support

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,26 @@
+queue_rules:
+  - name: default
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "approved-reviews-by=@chaos/powerman"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+      - -title~=^\[*[Ww][Ii][Pp]
+
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - -title~=^\[*[Ww][Ii][Pp]
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      queue:
+        name: default
+        method: merge
+        update_method: rebase


### PR DESCRIPTION
Problem: Mergifyio is a nice bot to auto rebase and merge PRs that are approved and have passed all tests.

Add initial mergify support.  Initial reviewers that can approve pull requests are on team @chaos/powerman.  PRs must be tagged with the merge-when-passing label.