### PR TITLE
mergify: fix approved-reviews-by typo

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,7 +16,7 @@ pull_request_rules:
       - label="merge-when-passing"
       - label!="work-in-progress"
       - -title~=^\[*[Ww][Ii][Pp]
-      - "approved-reviews-by=@flux-framework/core"
+      - "approved-reviews-by=@chaos/powerman"
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
     actions:


### PR DESCRIPTION
Problem: An approved-reviews-by rule copy and pasted a team from another project.

Update the rule so @chaos/powerman is the set of reviewers for this project.