### PR TITLE
Update license headers to SPDX license identifier

### DIFF
--- a/src/httppower/httppower.c
+++ b/src/httppower/httppower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2007 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2007 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/argv.c
+++ b/src/libcommon/argv.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2003 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/debug.c
+++ b/src/libcommon/debug.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/error.c
+++ b/src/libcommon/error.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/hprintf.c
+++ b/src/libcommon/hprintf.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2003 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/test/argv.c
+++ b/src/libcommon/test/argv.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/test/xregex.c
+++ b/src/libcommon/test/xregex.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/libcommon/xmalloc.c
+++ b/src/libcommon/xmalloc.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/xpoll.c
+++ b/src/libcommon/xpoll.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/xpty.c
+++ b/src/libcommon/xpty.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/xread.c
+++ b/src/libcommon/xread.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/xregex.c
+++ b/src/libcommon/xregex.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001-2008 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/libcommon/xsignal.c
+++ b/src/libcommon/xsignal.c
@@ -1,26 +1,12 @@
- /*****************************************************************************
- *  Copyright (C) 2004-2008 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/plmpower/plmpower.c
+++ b/src/plmpower/plmpower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2007 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2007 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* plmpower.c - control Insteon/X10 devices via SmartLabs PLM 2412S */
 

--- a/src/powerman/arglist.c
+++ b/src/powerman/arglist.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* Args used to be stored in a List, but gprof showed that very large
  * configurations spent a lot of time doing linear search of arg list for

--- a/src/powerman/client.c
+++ b/src/powerman/client.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* This is the component of the server that deals with clients.
  * The client itself is contained in powerman.c.

--- a/src/powerman/daemon.c
+++ b/src/powerman/daemon.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/powerman/device.c
+++ b/src/powerman/device.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see <http://www.llnl.gov/linux/powerman/>.
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* Primary entry points to this module are:
  *

--- a/src/powerman/device_pipe.c
+++ b/src/powerman/device_pipe.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2003 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /*
  * Implement connect/disconnect device methods for pipes.

--- a/src/powerman/device_serial.c
+++ b/src/powerman/device_serial.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2003 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see <http://www.llnl.gov/linux/powerman/>.
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /*
  * Implement connect/disconnect device methods for serial devices.

--- a/src/powerman/device_tcp.c
+++ b/src/powerman/device_tcp.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /*
  * Implement connect/disconnect/preprocess methods for tcp/telnet devices.

--- a/src/powerman/libpowerman.c
+++ b/src/powerman/libpowerman.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2008 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2008 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /*
  * libpowerman.c - simple powerman client library

--- a/src/powerman/libpowerman.h
+++ b/src/powerman/libpowerman.h
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #ifndef LIBPOWERMAN_H
 #define LIBPOWERMAN_H

--- a/src/powerman/parse_lex.l
+++ b/src/powerman/parse_lex.l
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001-2008 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton (uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see <http://www.llnl.gov/linux/powerman/>.
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 %x lex_incl lex_str
 

--- a/src/powerman/parse_tab.y
+++ b/src/powerman/parse_tab.y
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001-2002 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton (uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see <http://www.llnl.gov/linux/powerman/>.
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 %{
 #if HAVE_CONFIG_H

--- a/src/powerman/parse_util.c
+++ b/src/powerman/parse_util.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see <http://www.llnl.gov/linux/powerman/>.
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/powerman/pluglist.c
+++ b/src/powerman/pluglist.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -333,14 +319,13 @@ static void _usage(void)
 static void _license(void)
 {
     printf(
- "Copyright (C) 2001-2008 The Regents of the University of California.\n"
- "Produced at Lawrence Livermore National Laboratory.\n"
- "Written by Andrew Uselton <uselton2@llnl.gov>.\n"
- "http://www.llnl.gov/linux/powerman/\n"
- "UCRL-CODE-2002-008\n\n"
- "PowerMan is free software; you can redistribute it and/or modify it\n"
- "under the terms of the GNU General Public License as published by\n"
- "the Free Software Foundation.\n");
+ "Copyright (C) 2001 The Regents of the University of California.\n"
+ "(c.f. DISCLAIMER, COPYING)\n"
+ "\n"
+ "This file is part of Powerman, a remote power management program.\n"
+ "For details, see https://github.com/chaos/powerman.\n"
+ "\n"
+ "SPDX-License-Identifier: GPL-2.0-or-later\n");
     exit(1);
 }
 

--- a/src/powerman/powermand.c
+++ b/src/powerman/powermand.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/powerman/test/apiclient.c
+++ b/src/powerman/test/apiclient.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2008 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2008 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* cli.c - simple client to demo the libpowerman api */
 

--- a/src/powerman/test/pluglist.c
+++ b/src/powerman/test/pluglist.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004-2008 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /*
  * Test driver for pluglist module.

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2021 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Albert Chu <chu11@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2021 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://code.google.com/p/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/snmppower/snmppower.c
+++ b/src/snmppower/snmppower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************\
- *  Copyright (C) 2010 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2010 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/test/baytech.c
+++ b/test/baytech.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see <http://www.llnl.gov/linux/powerman/>.
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* baytech.c - baytech simulator */
 

--- a/test/cyclades.c
+++ b/test/cyclades.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see <http://www.llnl.gov/linux/powerman/>.
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* cyclades.c - simulate cyclades power controllers */
 

--- a/test/dli.c
+++ b/test/dli.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* dli.c - mimic httppower talking to a Digital Loggers Inc LPC */
 

--- a/test/gpib.c
+++ b/test/gpib.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* gpib.c - gpib-utils hp3488/ics8064 simulator */
 

--- a/test/icebox.c
+++ b/test/icebox.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* icebox.c - icebox simulator */
 

--- a/test/ilom.c
+++ b/test/ilom.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/test/ipmipower.c
+++ b/test/ipmipower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* ipmipower.c - simulate FreeIPMI ipmipower */
 

--- a/test/lom.c
+++ b/test/lom.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/test/openbmc-httppower.c
+++ b/test/openbmc-httppower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* openbmc-httppower.c - mimic httppower talking to a openbmc server */
 

--- a/test/redfish-httppower.c
+++ b/test/redfish-httppower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2021 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Albert Chu <chu11@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2021 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* redfish-httppower.c - mimic httppower talking to a redfish server */
 

--- a/test/redfishpower.c
+++ b/test/redfishpower.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2021 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Albert Chu <chu11@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2021 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://code.google.com/p/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* redfishpower.c - simulate redfishpower */
 

--- a/test/swpdu.c
+++ b/test/swpdu.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2004 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Jim Garlick <garlick@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 /* swpdu.c - appro swpdu simulator */
 

--- a/test/vpcd.c
+++ b/test/vpcd.c
@@ -1,26 +1,12 @@
-/*****************************************************************************
- *  Copyright (C) 2001 The Regents of the University of California.
- *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
- *  Written by Andrew Uselton <uselton2@llnl.gov>
- *  UCRL-CODE-2002-008.
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
  *
- *  This file is part of PowerMan, a remote power management program.
- *  For details, see http://github.com/chaos/powerman/
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
  *
- *  PowerMan is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
- *
- *  PowerMan is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with PowerMan; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
-\*****************************************************************************/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
Problem: All current license headers use a free form written text.  This makes the files difficult to parse by code repos looking for license information.

Use the SPDX-License-Identifier for clear parseable license identification.

---

side notes, whenever there was a "2004-2008" or whatever range, I just put in "2004", as that was the more common thing in powerman.

