### PR TITLE
Add license text to header files

### DIFF
--- a/src/libcommon/argv.h
+++ b/src/libcommon/argv.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_ARGV_H
 #define PM_ARGV_H
 

--- a/src/libcommon/client_proto.h
+++ b/src/libcommon/client_proto.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2002 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_CLIENT_PROTO_H
 #define PM_CLIENT_PROTO_H
 

--- a/src/libcommon/debug.h
+++ b/src/libcommon/debug.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_DEBUG_H
 #define PM_DEBUG_H
 

--- a/src/libcommon/error.h
+++ b/src/libcommon/error.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_ERROR_H
 #define PM_ERROR_H
 

--- a/src/libcommon/hprintf.h
+++ b/src/libcommon/hprintf.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_HPRINTF_H
 #define PM_HPRINTF_H
 

--- a/src/libcommon/powerman.h
+++ b/src/libcommon/powerman.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_POWERMAN_H
 #define PM_POWERMAN_H
 

--- a/src/libcommon/xmalloc.h
+++ b/src/libcommon/xmalloc.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_XMALLOC_H
 #define PM_XMALLOC_H
 

--- a/src/libcommon/xpoll.h
+++ b/src/libcommon/xpoll.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_XPOLL_H
 #define PM_XPOLL_H
 

--- a/src/libcommon/xpty.h
+++ b/src/libcommon/xpty.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_XPTY_H
 #define PM_XPTY_H
 

--- a/src/libcommon/xread.h
+++ b/src/libcommon/xread.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_XREAD_H
 #define PM_XREAD_H
 

--- a/src/libcommon/xregex.h
+++ b/src/libcommon/xregex.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_XREGEX_H
 #define PM_XREGEX_H
 

--- a/src/libcommon/xsignal.h
+++ b/src/libcommon/xsignal.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_XSIGNAL_H
 #define PM_XSIGNAL_H
 

--- a/src/libcommon/xtypes.h
+++ b/src/libcommon/xtypes.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_XTYPES_H
 #define PM_XTYPES_H
 

--- a/src/powerman/arglist.h
+++ b/src/powerman/arglist.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 /*
  * The ArgList is used to pass the list of "target nodes" into a device
  * script, and then to pass the result back to the client.

--- a/src/powerman/client.h
+++ b/src/powerman/client.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_CLIENT_H
 #define PM_CLIENT_H
 

--- a/src/powerman/daemon.h
+++ b/src/powerman/daemon.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_DAEMON_H
 #define PM_DAEMON_H
 

--- a/src/powerman/device.h
+++ b/src/powerman/device.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_DEVICE_H
 #define PM_DEVICE_H
 

--- a/src/powerman/device_pipe.h
+++ b/src/powerman/device_pipe.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_DEVICE_PIPE_H
 #define PM_DEVICE_PIPE_H
 

--- a/src/powerman/device_private.h
+++ b/src/powerman/device_private.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_DEVICE_PRIVATE_H
 #define PM_DEVICE_PRIVATE_H
 

--- a/src/powerman/device_serial.h
+++ b/src/powerman/device_serial.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2003 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_DEVICE_SERIAL_H
 #define PM_DEVICE_SERIAL_H
 

--- a/src/powerman/device_tcp.h
+++ b/src/powerman/device_tcp.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_DEVICE_TCP_H
 #define PM_DEVICE_TCP_H
 

--- a/src/powerman/parse_util.h
+++ b/src/powerman/parse_util.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2001 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_PARSE_UTIL_H
 #define PM_PARSE_UTIL_H
 

--- a/src/powerman/pluglist.h
+++ b/src/powerman/pluglist.h
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright (C) 2004 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
 #ifndef PM_PLUGLIST_H
 #define PM_PLUGLIST_H
 


### PR DESCRIPTION
Problem: License headers are missing for most project .h header files.

Add license info to header files.