### PR TITLE
cull unused test options and update manual pages

### DIFF
--- a/man/powerman.1.in
+++ b/man/powerman.1.in
@@ -8,8 +8,8 @@ powerman \- power on/off nodes
 .B powerman
 provides power management in a data center or compute cluster environment.
 It performs operations such as power on, power off, and power cycle
-via remote power controller (RPC) devices.
-Target hostnames are mapped to plugs on RPC devices in
+via remote power controller devices.
+Target hostnames are mapped to plugs on devices in
 .I powerman.conf(5).
 .SH OPTIONS
 .TP
@@ -25,7 +25,7 @@ Power cycle targets.
 .I "-q, --query-all"
 Query plug status of all targets.
 Status is not cached;  each time this option is used, powermand
-queries the appropriate RPC's.  Targets connected to RPC's that could
+queries the appropriate devices.  Targets connected to devices that could
 not be contacted (e.g. due to network failure) are reported as
 status "unknown".  If possible, output will be compressed into host
 ranges.
@@ -78,13 +78,13 @@ Query node temperature of targets.
 .I "-t, --temp-all"
 Query node temperature of all targets.
 Temperature information is not interpreted by powerman and is reported
-as received from the RPC on one line per target, prefixed by target name.
+as received from the device on one line per target, prefixed by target name.
 .SH TEST/DEBUG OPTIONS
 The following options may be helpful in the test environment or when debugging
 device scripts.
 .TP
 .I "-T, --telemetry"
-Causes RPC telemetry information to be displayed as commands are processed.
+Causes device telemetry information to be displayed as commands are processed.
 Useful for debugging device scripts.
 .TP
 .I "-R, --retry-connect N"

--- a/man/powerman.1.in
+++ b/man/powerman.1.in
@@ -46,14 +46,6 @@ ranges.
 .I "-Q, --query targets"
 Query plug status of specific targets.
 .TP
-.I "-n, --soft-all"
-Query soft power status of all targets (if implemented by RPC).
-In this context, a node in the OFF state could be ON at the plug but
-operating in standby power mode.
-.TP
-.I "-N, --soft targets"
-Query soft power status of specific targets (if implemented by RPC).
-.TP
 .I "-b, --beacon-all"
 Query beacon status of all targets (if implemented by RPC).
 .TP

--- a/man/powerman.1.in
+++ b/man/powerman.1.in
@@ -22,19 +22,6 @@ Power OFF targets.
 .I "-c, --cycle targets"
 Power cycle targets.
 .TP
-.I "-r, --reset targets"
-Assert hardware reset for targets (if implemented by RPC).
-.TP
-.I "-f, --flash targets"
-Turn beacon ON for targets (if implemented by RPC).
-.TP
-.I "-u, --unflash targets"
-Turn beacon OFF for targets (if implemented by RPC).
-.TP
-.I "-l, --list"
-List available targets.  If possible, output will be compressed into
-a host range (see TARGET SPECIFICATION below).
-.TP
 .I "-q, --query-all"
 Query plug status of all targets.
 Status is not cached;  each time this option is used, powermand
@@ -46,44 +33,72 @@ ranges.
 .I "-Q, --query targets"
 Query plug status of specific targets.
 .TP
-.I "-b, --beacon-all"
-Query beacon status of all targets (if implemented by RPC).
-.TP
-.I "-B, --beacon targets"
-Query beacon status of specific targets (if implemented by RPC).
-.TP
-.I "-t, --temp-all"
-Query node temperature of all targets (if implemented by RPC).
-Temperature information is not interpreted by powerman and is reported
-as received from the RPC on one line per target, prefixed by target name.
-.TP
-.I "-P, --temp targets"
-Query node temperature of specific targets (if implemented by RPC).
-.TP
-.I "-L, --license"
-Show powerman license information.
-.TP
 .I "-h, --server-host host[:port]"
 Connect to a powerman daemon on non-default host and optionally port.
+.TP
+.I "-x, --exprange"
+Expand host ranges in query responses.
+.TP
+.I "-l, --list"
+List available targets.  If possible, output will be compressed into
+a host range (see TARGET SPECIFICATION below).
 .TP
 .I "-V, --version"
 Display the powerman version number and exit.
 .TP
-.I "-D, --device"
-Displays RPC status information.  If targets are specified, only RPC's
-matching the target list are displayed.
+.I "-L, --license"
+Show powerman license information.
+.TP
+.I "-g, --genders"
+Interpret targets as genders attributes rather than node names.  Each attribute
+is expanded to the list of nodes that have that attribute, then those lists
+are combined to make a list of target node names.
+.SH EXTRA OPTIONS
+The following options may or may not be available, depending on whether or
+not the device implements them.
+.TP
+.I "-r, --reset targets"
+Assert hardware reset for targets.
+.TP
+.I "-f, --flash targets"
+Turn beacon ON for targets.
+.TP
+.I "-u, --unflash targets"
+Turn beacon OFF for targets.
+.TP
+.I "-B, --beacon targets"
+Query beacon status of targets.
+.TP
+.I "-b, --beacon-all"
+Query beacon status of all targets.
+.TP
+.I "-P, --temp targets"
+Query node temperature of targets.
+.TP
+.I "-t, --temp-all"
+Query node temperature of all targets.
+Temperature information is not interpreted by powerman and is reported
+as received from the RPC on one line per target, prefixed by target name.
+.SH TEST/DEBUG OPTIONS
+The following options may be helpful in the test environment or when debugging
+device scripts.
 .TP
 .I "-T, --telemetry"
 Causes RPC telemetry information to be displayed as commands are processed.
 Useful for debugging device scripts.
 .TP
-.I "-x, --exprange"
-Expand host ranges in query responses.
+.I "-R, --retry-connect N"
+Retry connect to server up to N times with a 100ms delay after each failure.
 .TP
-.I "-g, --genders"
-If configured with the genders(3) package, this option tells powerman that
-targets are genders attributes that map to node names rather than the
-node names themselves.
+.I "-Z, --dump-cmds"
+List the powerman protocol requests that would have been sent by this
+command line, and exit.
+.TP
+.I "-D, --device NAME"
+Displays device status information for the named device.
+.TP
+.I "-d, --device-all"
+Displays device status information for all devices.
 .SH "TARGET SPECIFICATION"
 .B powerman
 target hostnames may be specified as comma separated or space separated

--- a/man/powermand.8.in
+++ b/man/powermand.8.in
@@ -17,6 +17,15 @@ Override the default location of the powerman configuration file
 .I "-f, --foreground"
 Do not daemonize, and send debugging/error messages to stderr instead of syslog.
 .TP
+.I "-s, --stdio"
+Talk to a client on stdin/stdout rather than listening for network connections.
+This is useful for testing new configurations, since the powerman client
+protocol is friendly to humans.
+.TP
+.I "-Y, --short-circuit-delay"
+Ignore all device script delay statements.  This is useful for testing
+with simulated devices, where the delays slow down testing for no benefit.
+.TP
 .I "-d, --debug mask"
 Set mask for debugging output.
 .TP

--- a/man/powermand.8.in
+++ b/man/powermand.8.in
@@ -26,9 +26,6 @@ Provide a synopsis of the command options.
 .I "-V, --version"
 Display the powerman version number and exit.
 
-.B PowerMan
-and exit.
-
 .SH "FILES"
 @X_SBINDIR@/powermand
 .br

--- a/src/powerman/client.c
+++ b/src/powerman/client.c
@@ -1153,13 +1153,14 @@ bool cli_server_done(void)
     return server_done;
 }
 
-void cli_start(bool use_stdio, bool oc)
+void cli_start(bool use_stdio)
 {
-    if (use_stdio)
+    if (use_stdio) {
         _create_client_stdio();
+        one_client = true;
+    }
     else
         _listen_client();
-    one_client = oc;
 }
 
 /*

--- a/src/powerman/client.h
+++ b/src/powerman/client.h
@@ -14,7 +14,7 @@
 void cli_init(void);
 void cli_fini(void);
 
-void cli_start(bool use_stdio, bool one_client);
+void cli_start(bool use_stdio);
 void cli_listen_fds(int **fds, int *len);
 bool cli_server_done(void);
 

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
         case 'Z':              /* --dump-cmds */
             dumpcmds = true;
             break;
-        case 'R':              /* --retry-connect=N (sleep 1s after fail) */
+        case 'R':              /* --retry-connect=N (sleep 100ms after fail) */
             errno = 0;
             retry_connect = strtoul (optarg, NULL, 10);
             if (errno != 0 || retry_connect < 1)

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -55,8 +55,6 @@ typedef struct {
 static void _push_genders_hosts(hostlist_t targets, char *s);
 #endif
 static int  _connect_to_server_tcp(char *host, char *port, int retries);
-static int  _connect_to_server_pipe(char *server_path, char *config_path,
-                                    bool short_circuit_delays);
 static void _usage(void);
 static void _license(void);
 static void _version(void);
@@ -73,7 +71,7 @@ static void _cmd_print(cmd_t *cp);
 
 static char *prog;
 
-#define OPTIONS "0:1:c:r:f:u:B:blQ:qP:tD:dTxgh:S:C:YVLZIR:"
+#define OPTIONS "0:1:c:r:f:u:B:blQ:qP:tD:dTxgh:VLZR:"
 #if HAVE_GETOPT_LONG
 #define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
@@ -96,13 +94,9 @@ static const struct option longopts[] = {
     {"exprange",    no_argument,        0, 'x'},
     {"genders",     no_argument,        0, 'g'},
     {"server-host", required_argument,  0, 'h'},
-    {"server-path", required_argument,  0, 'S'},
-    {"config-path", required_argument,  0, 'C'},
-    {"short-circuit-delays", no_argument,  0, 'Y'},
     {"version",     no_argument,        0, 'V'},
     {"license",     no_argument,        0, 'L'},
     {"dump-cmds",   no_argument,        0, 'Z'},
-    {"ignore-errs", no_argument,        0, 'I'},
     {"retry-connect", required_argument, 0, 'R'},
     {0, 0, 0, 0},
 };
@@ -119,14 +113,10 @@ int main(int argc, char **argv)
     char *host = DFLT_HOSTNAME;
     bool genders = false;
     bool dumpcmds = false;
-    bool ignore_errs = false;
-    char *server_path = NULL;
-    char *config_path = NULL;
     unsigned long retry_connect = 0;
     List commands;  /* list-o-cmd_t's */
     ListIterator itr;
     cmd_t *cp;
-    bool short_circuit_delays = false;
 
     prog = basename(argv[0]);
     err_init(prog);
@@ -182,9 +172,6 @@ int main(int argc, char **argv)
         case 'd':              /* --device-all */
             _cmd_create(commands, CP_DEVICE_ALL, NULL, false);
             break;
-        case 'Y':              /* --short-circuit-delays */
-            short_circuit_delays = true;
-            break;
         case 'h':              /* --server-host host[:port] */
             if ((p = strchr(optarg, ':'))) {
                 *p++ = '\0';
@@ -213,17 +200,8 @@ int main(int argc, char **argv)
             err_exit(false, "not configured with genders support");
 #endif
             break;
-        case 'S':              /* --server-path */
-            server_path = optarg;
-            break;
-        case 'C':              /* --config-path */
-            config_path = optarg;
-            break;
         case 'Z':              /* --dump-cmds */
             dumpcmds = true;
-            break;
-        case 'I':              /* --ignore-errs */
-            ignore_errs = true;
             break;
         case 'R':              /* --retry-connect=N (sleep 1s after fail) */
             errno = 0;
@@ -238,8 +216,6 @@ int main(int argc, char **argv)
         }
     }
     if (list_is_empty(commands))
-        _usage();
-    if (short_circuit_delays && !server_path)
         _usage();
 
     /* For backwards compat with powerman 2.0 and earlier,
@@ -279,11 +255,7 @@ int main(int argc, char **argv)
 
     /* Establish connection to server and start protocol.
      */
-    if (server_path)
-        server_fd = _connect_to_server_pipe(server_path, config_path,
-                                            short_circuit_delays);
-    else
-        server_fd = _connect_to_server_tcp(host, port, retry_connect);
+    server_fd = _connect_to_server_tcp(host, port, retry_connect);
     _process_version(server_fd);
     _expect(server_fd, CP_PROMPT);
 
@@ -292,8 +264,6 @@ int main(int argc, char **argv)
     itr = list_iterator_create(commands);
     while ((cp = list_next(itr))) {
         res = _cmd_execute(cp, server_fd);
-        if (ignore_errs)
-            res = 0;
         if (res != 0)
             break;
     }
@@ -483,41 +453,6 @@ static void _cmd_print(cmd_t *cp)
     assert(cp->sendstr != NULL);
 
     printf("%s%s", cp->sendstr, CP_EOL);
-}
-
-static int _connect_to_server_pipe(char *server_path, char *config_path,
-                                   bool short_circuit_delays)
-{
-    int saved_stderr;
-    char cmd[128];
-    char **argv;
-    pid_t pid;
-    int fd;
-
-    saved_stderr = dup(STDERR_FILENO);
-    if (saved_stderr < 0)
-        err_exit(true, "dup stderr");
-    snprintf(cmd, sizeof(cmd), "powermand -sf -c %s", config_path);
-    argv = argv_create(cmd, "");
-    if (short_circuit_delays)
-        argv = argv_append(argv, "-Y");
-    pid = xforkpty(&fd, NULL, 0);
-    switch (pid) {
-        case -1:
-            err_exit(true, "forkpty error");
-        case 0: /* child */
-            if (dup2(saved_stderr, STDERR_FILENO) < 0)
-                err_exit(true, "dup2 stderr");
-            close(saved_stderr);
-            xcfmakeraw(STDIN_FILENO);
-            execv(server_path, argv);
-            err_exit(true, "exec %s", server_path);
-        default: /* parent */
-            close(saved_stderr);
-            break;
-    }
-    argv_destroy(argv);
-    return fd;
 }
 
 static int _connect_any(struct addrinfo *addr)

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -293,14 +293,23 @@ static void _usage(void)
 #endif
     printf("  -h,--server-host host[:port]  Connect to remote server\n");
     printf("  -x,--exprange        Expand host ranges in query response\n");
-    printf("  -T,--telemtery       Show device conversation for debugging\n");
     printf("  -l,--list            List available targets\n");
+    printf("  -V,--version         Show powerman version\n");
+    printf("  -L,--license         Show powerman license\n");
     printf ("The following are not implemented by all devices:\n");
     printf("  -r,--reset targets   Assert hardware reset\n");
     printf("  -f,--flash targets   Turn beacon on\n");
     printf("  -u,--unflash targets Turn beacon off\n");
-    printf("  -b,--beacon targets  Query beacon status\n");
+    printf("  -B,--beacon targets  Query beacon status of targets\n");
+    printf("  -b,--beacon-all      Query beacon status of all targets\n");
     printf("  -P,--temp targets    Query temperature\n");
+    printf("  -t,--temp-all        Query temperature of all targets\n");
+    printf ("For testing/debugging:\n");
+    printf("  -T,--telemtery       Show device conversation for debugging\n");
+    printf("  -R,--retry-connect=N Retry connect to server up to N times\n");
+    printf("  -Z,--dump-cmds       Show powerman protocol requests and exit\n");
+    printf("  -D,--device=NAME     Show statistics of device NAME\n");
+    printf("  -d,--device-all      Show statistics of all devices\n");
     exit(1);
 }
 

--- a/src/powerman/powermand.c
+++ b/src/powerman/powermand.c
@@ -152,11 +152,13 @@ int main(int argc, char **argv)
 static void _usage(char *prog)
 {
     printf("Usage: %s [OPTIONS]\n", prog);
-    printf("  -c --conf <filename>   Specify config file path\n");
-    printf("  -d --debug <mask>      Set debug mask [0]\n");
-    printf("  -f --foreground        Don't daemonize\n");
-    printf("  -V --version           Report powerman version\n");
-    printf("  -s --stdio             Talk to client on stdin/stdout\n");
+    printf("  -c,--conf=PATH            Specify config file path\n");
+    printf("  -f,--foreground           Don't daemonize\n");
+    printf("  -s,--stdio                Talk to client on stdin/stdout\n");
+    printf("  -Y,--short-circuit-delay  Change all device delays to zero\n");
+    printf("  -d,--debug=MASK           Enable debug logging\n");
+    printf("  -V,--version              Report powerman version\n");
+    printf("  -h,--help                 Display help\n");
     exit(0);
 }
 

--- a/src/powerman/powermand.c
+++ b/src/powerman/powermand.c
@@ -103,6 +103,7 @@ int main(int argc, char **argv)
             break;
         case 's': /* --stdio */
             use_stdio = true;
+            daemonize = false;
             break;
         case 'h': /* --help */
         default:
@@ -111,9 +112,6 @@ int main(int argc, char **argv)
             break;
         }
     }
-
-    if (use_stdio && daemonize)
-        err_exit(false, "--stdio should only be used with --foreground");
 
     if (!config_filename)
         config_filename = hsprintf("%s/%s/%s", X_SYSCONFDIR,

--- a/src/powerman/powermand.c
+++ b/src/powerman/powermand.c
@@ -48,7 +48,7 @@ static void _noop_handler(int signum);
 static void _exit_handler(int signum);
 static void _select_loop(void);
 
-#define OPTIONS "c:fhd:VsY1"
+#define OPTIONS "c:fhd:VsY"
 #if HAVE_GETOPT_LONG
 #define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
@@ -59,7 +59,6 @@ static const struct option longopts[] = {
     {"version",         no_argument,        0, 'V'},
     {"stdio",           no_argument,        0, 's'},
     {"short-circuit-delay", no_argument,    0, 'Y'},
-    {"one-client",      no_argument,        0, '1'},
     {0, 0, 0, 0}
 };
 #else
@@ -73,7 +72,6 @@ int main(int argc, char **argv)
     bool daemonize = true;
     bool use_stdio = false;
     bool short_circuit_delay = false;
-    bool one_client = false;
 
     /* parse command line options */
     err_init(argv[0]);
@@ -105,10 +103,6 @@ int main(int argc, char **argv)
             break;
         case 's': /* --stdio */
             use_stdio = true;
-            one_client = true;
-            break;
-        case '1': /* --one-client */
-            one_client = true;
             break;
         case 'h': /* --help */
         default:
@@ -136,7 +130,7 @@ int main(int argc, char **argv)
     xsignal(SIGINT, _exit_handler);
     xsignal(SIGPIPE, SIG_IGN);
 
-    cli_start(use_stdio, one_client);
+    cli_start(use_stdio);
 
     if (daemonize) {
         char *rundir = hsprintf("%s/powerman", X_RUNSTATEDIR);
@@ -165,7 +159,6 @@ static void _usage(char *prog)
     printf("  -f --foreground        Don't daemonize\n");
     printf("  -V --version           Report powerman version\n");
     printf("  -s --stdio             Talk to client on stdin/stdout\n");
-    printf("  -1 --one-client        Terminate when client disconnects\n");
     exit(0);
 }
 

--- a/t/t0021-remote-powerman.t
+++ b/t/t0021-remote-powerman.t
@@ -38,7 +38,7 @@ test_expect_success 'create controlling powerman.conf' '
 	cat >powerman.conf <<-EOT
 	listen "$testaddr"
 	include "$powermandev"
-	device "p0" "powerman" "$powermand --stdio -c rpowerman.conf -f |&"
+	device "p0" "powerman" "$powermand --stdio -c rpowerman.conf |&"
 	node "t[0-63]"   "p0"
 	EOT
 '


### PR DESCRIPTION
Problem: the powerman client has some odd test options that were used by the previous test harness, and are now unused.

Cull those options.

Ensure `Usage:` output, `powerman(1)`, and `powerman(8)` fully document all options.