### PR TITLE
clean up powerman client options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,6 @@ AC_CHECK_FILES(/dev/ptc)
 # Checks for header files.
 ##
 AC_CHECK_HEADERS( \
-  getopt.h \
   poll.h \
   sys/select.h \
   sys/syscall.h \
@@ -93,7 +92,6 @@ RRA_WITH_SYSTEMD_UNITDIR
 # Checks for library functions.
 ##
 AC_CHECK_FUNCS( \
-  getopt_long \
   cfmakeraw
 )
 AC_SEARCH_LIBS([bind],[socket])

--- a/man/powerman.1.in
+++ b/man/powerman.1.in
@@ -26,9 +26,9 @@ Power cycle targets.
 Query plug status of targets, if specified, or all targets if not.
 Status is not cached;  each time this option is used, powermand
 queries the appropriate devices.  Targets connected to devices that could
-not be contacted (e.g. due to network failure) are reported as
-status "unknown".  If possible, output will be compressed into host
-ranges.
+not be contacted (e.g. due to network failure) or had some other type of
+error or are reported as status "unknown".  If possible, output will be
+compressed into host ranges.
 .TP
 .I "-l, --list"
 List available targets.  If possible, output will be compressed into

--- a/man/powerman.1.in
+++ b/man/powerman.1.in
@@ -64,6 +64,9 @@ Display the powerman version number and exit.
 .I "-L, --license"
 Show powerman license information.
 .TP
+.I "-H, --help"
+Show command usage.
+.TP
 .I "-g, --genders"
 Interpret targets as genders attributes rather than node names.  Each attribute
 is expanded to the list of nodes that have that attribute, then those lists

--- a/man/powerman.1.in
+++ b/man/powerman.1.in
@@ -3,7 +3,7 @@
 powerman \- power on/off nodes
 .SH SYNOPSIS
 .B pm
-.I "[-options] -action [targets] [-action [targets] ...]"
+.I "[OPTIONS] [ACTION [TARGETS ...]]"
 .SH DESCRIPTION
 .B powerman
 provides power management in a data center or compute cluster environment.
@@ -11,37 +11,52 @@ It performs operations such as power on, power off, and power cycle
 via remote power controller devices.
 Target hostnames are mapped to plugs on devices in
 .I powerman.conf(5).
-.SH OPTIONS
+.SH ACTIONS
 .TP
-.I "-1, --on targets"
+.I "-1, --on"
 Power ON targets.
 .TP
-.I "-0, --off targets"
+.I "-0, --off"
 Power OFF targets.
 .TP
-.I "-c, --cycle targets"
+.I "-c, --cycle"
 Power cycle targets.
 .TP
-.I "-q, --query-all"
-Query plug status of all targets.
+.I "-q, --query"
+Query plug status of targets, if specified, or all targets if not.
 Status is not cached;  each time this option is used, powermand
 queries the appropriate devices.  Targets connected to devices that could
 not be contacted (e.g. due to network failure) are reported as
 status "unknown".  If possible, output will be compressed into host
 ranges.
 .TP
-.I "-Q, --query targets"
-Query plug status of specific targets.
+.I "-l, --list"
+List available targets.  If possible, output will be compressed into
+a host range (see TARGET SPECIFICATION below).
+.TP
+.I "-r, --reset"
+Assert hardware reset for targets.
+.TP
+.I "-f, --flash"
+Turn beacon ON for targets.
+.TP
+.I "-u, --unflash"
+Turn beacon OFF for targets.
+.TP
+.I "-B, --beacon"
+Query beacon status of targets, if specified, or all targets if not.
+.TP
+.I "-t, --temp"
+Query node temperature of targets, if specified, or all targets if not.
+Temperature information is not interpreted by powerman and is reported
+as received from the device on one line per target, prefixed by target name.
+.SH OPTIONS
 .TP
 .I "-h, --server-host host[:port]"
 Connect to a powerman daemon on non-default host and optionally port.
 .TP
 .I "-x, --exprange"
 Expand host ranges in query responses.
-.TP
-.I "-l, --list"
-List available targets.  If possible, output will be compressed into
-a host range (see TARGET SPECIFICATION below).
 .TP
 .I "-V, --version"
 Display the powerman version number and exit.
@@ -53,32 +68,6 @@ Show powerman license information.
 Interpret targets as genders attributes rather than node names.  Each attribute
 is expanded to the list of nodes that have that attribute, then those lists
 are combined to make a list of target node names.
-.SH EXTRA OPTIONS
-The following options may or may not be available, depending on whether or
-not the device implements them.
-.TP
-.I "-r, --reset targets"
-Assert hardware reset for targets.
-.TP
-.I "-f, --flash targets"
-Turn beacon ON for targets.
-.TP
-.I "-u, --unflash targets"
-Turn beacon OFF for targets.
-.TP
-.I "-B, --beacon targets"
-Query beacon status of targets.
-.TP
-.I "-b, --beacon-all"
-Query beacon status of all targets.
-.TP
-.I "-P, --temp targets"
-Query node temperature of targets.
-.TP
-.I "-t, --temp-all"
-Query node temperature of all targets.
-Temperature information is not interpreted by powerman and is reported
-as received from the device on one line per target, prefixed by target name.
 .SH TEST/DEBUG OPTIONS
 The following options may be helpful in the test environment or when debugging
 device scripts.
@@ -90,15 +79,9 @@ Useful for debugging device scripts.
 .I "-R, --retry-connect N"
 Retry connect to server up to N times with a 100ms delay after each failure.
 .TP
-.I "-Z, --dump-cmds"
-List the powerman protocol requests that would have been sent by this
-command line, and exit.
-.TP
-.I "-D, --device NAME"
-Displays device status information for the named device.
-.TP
-.I "-d, --device-all"
-Displays device status information for all devices.
+.I "-d, --device[=NAME]"
+Displays device status information for the named device, if specified,
+or all devices if not.
 .SH "TARGET SPECIFICATION"
 .B powerman
 target hostnames may be specified as comma separated or space separated

--- a/src/plmpower/plmpower.c
+++ b/src/plmpower/plmpower.c
@@ -26,9 +26,7 @@
 #endif
 #include <stdio.h>
 #include <libgen.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -170,8 +168,6 @@ static unsigned long    x10_attempts = 3;
 static int              insteon_tmout = 1000; /* (msec) */
 
 #define OPTIONS "d:Tx:t:S:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static struct option longopts[] = {
     { "device",         required_argument, 0, 'd' },
     { "testmode",       no_argument,       0, 'T' },
@@ -180,9 +176,6 @@ static struct option longopts[] = {
     { "single-cmd",     required_argument, 0, 'S' },
     {0,0,0,0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int
 main(int argc, char *argv[])
@@ -194,7 +187,7 @@ main(int argc, char *argv[])
 
     err_init(basename(argv[0]));
 
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != EOF) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != EOF) {
         switch (c) {
             case 'd':   /* --device */
                 device = optarg;

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -41,14 +41,6 @@
 #include "argv.h"
 #include "list.h"
 
-#define CMD_MAGIC 0x5565aafd
-typedef struct {
-    int magic;
-    char *fmt;
-    char **argv;
-    char *sendstr;
-} cmd_t;
-
 #if WITH_GENDERS
 static void _push_genders_hosts(hostlist_t targets, char *s);
 #endif
@@ -60,39 +52,31 @@ static int  _process_line(int fd);
 static void _expect(int fd, char *str);
 static int  _process_response(int fd);
 static void _process_version(int fd);
-static void _cmd_create(List cl, char *fmt, char *arg, bool prepend);
-static void _cmd_destroy(cmd_t *cp);
-static void _cmd_append(cmd_t *cp, char *arg);
-static void _cmd_prepare(cmd_t *cp, bool genders);
-static int  _cmd_execute(cmd_t *cp, int fd);
-static void _cmd_print(cmd_t *cp);
+static void _set_command (const char **command, const char *value);
 
 static char *prog;
 
-#define OPTIONS "0:1:c:r:f:u:B:blQ:qP:tD:dTxgh:VLZR:"
+#define OPTIONS "01crfubqtldTxgh:VLR:"
 static const struct option longopts[] = {
-    {"on",          required_argument,  0, '1'},
-    {"off",         required_argument,  0, '0'},
-    {"cycle",       required_argument,  0, 'c'},
-    {"reset",       required_argument,  0, 'r'},
-    {"flash",       required_argument,  0, 'f'},
-    {"unflash",     required_argument,  0, 'u'},
-    {"beacon",      required_argument,  0, 'B'},
-    {"beacon-all",  no_argument,        0, 'b'},
+    // command
+    {"on",          no_argument,        0, '1'},
+    {"off",         no_argument,        0, '0'},
+    {"cycle",       no_argument,        0, 'c'},
+    {"reset",       no_argument,        0, 'r'},
+    {"flash",       no_argument,        0, 'f'},
+    {"unflash",     no_argument,        0, 'u'},
+    {"beacon",      no_argument,        0, 'b'},
+    {"query",       no_argument,        0, 'q'},
+    {"temp",        no_argument,        0, 't'},
     {"list",        no_argument,        0, 'l'},
-    {"query",       required_argument,  0, 'Q'},
-    {"query-all",   no_argument,        0, 'q'},
-    {"temp",        required_argument,  0, 'P'},
-    {"temp-all",    no_argument,        0, 't'},
-    {"device",      required_argument,  0, 'D'},
-    {"device-all",  no_argument,        0, 'd'},
+    {"device",      no_argument,        0, 'd'},
+    // options
     {"telemetry",   no_argument,        0, 'T'},
     {"exprange",    no_argument,        0, 'x'},
     {"genders",     no_argument,        0, 'g'},
     {"server-host", required_argument,  0, 'h'},
     {"version",     no_argument,        0, 'V'},
     {"license",     no_argument,        0, 'L'},
-    {"dump-cmds",   no_argument,        0, 'Z'},
     {"retry-connect", required_argument, 0, 'R'},
     {0, 0, 0, 0},
 };
@@ -105,15 +89,16 @@ int main(int argc, char **argv)
     char *p, *port = DFLT_PORT;
     char *host = DFLT_HOSTNAME;
     bool genders = false;
-    bool dumpcmds = false;
     unsigned long retry_connect = 0;
-    List commands;  /* list-o-cmd_t's */
-    ListIterator itr;
-    cmd_t *cp;
+    const char *command = NULL;
+    bool telemetry = false;
+    bool exprange = false;
+    hostlist_t targets;
+    bool targets_required = false;
 
     prog = basename(argv[0]);
     err_init(prog);
-    commands = list_create((ListDelF)_cmd_destroy);
+    targets = hostlist_create(NULL);
 
     /* Parse options.
      */
@@ -121,49 +106,43 @@ int main(int argc, char **argv)
     while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
         case '1':              /* --on */
-            _cmd_create(commands, CP_ON, optarg, false);
+            _set_command(&command, CP_ON);
+            targets_required = true;
             break;
         case '0':              /* --off */
-            _cmd_create(commands, CP_OFF, optarg, false);
+            _set_command(&command, CP_OFF);
+            targets_required = true;
             break;
         case 'c':              /* --cycle */
-            _cmd_create(commands, CP_CYCLE, optarg, false);
+            _set_command(&command, CP_CYCLE);
+            targets_required = true;
             break;
         case 'r':              /* --reset */
-            _cmd_create(commands, CP_RESET, optarg, false);
+            _set_command(&command, CP_RESET);
+            targets_required = true;
             break;
         case 'l':              /* --list */
-            _cmd_create(commands, CP_NODES, NULL, false);
+            _set_command(&command, CP_NODES);
             break;
-        case 'Q':              /* --query */
-            _cmd_create(commands, CP_STATUS, optarg, false);
-            break;
-        case 'q':              /* --query-all */
-            _cmd_create(commands, CP_STATUS_ALL, NULL, false);
+        case 'q':              /* --query */
+            _set_command(&command, CP_STATUS);
             break;
         case 'f':              /* --flash */
-            _cmd_create(commands, CP_BEACON_ON, optarg, false);
+            _set_command(&command, CP_BEACON_ON);
+            targets_required = true;
             break;
         case 'u':              /* --unflash */
-            _cmd_create(commands, CP_BEACON_OFF, optarg, false);
+            _set_command(&command, CP_BEACON_OFF);
+            targets_required = true;
             break;
-        case 'B':              /* --beacon */
-            _cmd_create(commands, CP_BEACON, optarg, false);
+        case 'b':              /* --beacon */
+            _set_command(&command, CP_BEACON);
             break;
-        case 'b':              /* --beacon-all */;
-            _cmd_create(commands, CP_BEACON_ALL, NULL, false);
+        case 't':              /* --temp */
+            _set_command(&command, CP_TEMP);
             break;
-        case 'P':              /* --temp */
-            _cmd_create(commands, CP_TEMP, optarg, false);
-            break;
-        case 't':              /* --temp-all */
-            _cmd_create(commands, CP_TEMP_ALL, NULL, false);
-            break;
-        case 'D':              /* --device */
-            _cmd_create(commands, CP_DEVICE, optarg, false);
-            break;
-        case 'd':              /* --device-all */
-            _cmd_create(commands, CP_DEVICE_ALL, NULL, false);
+        case 'd':              /* --device */
+            _set_command(&command, CP_DEVICE);
             break;
         case 'h':              /* --server-host host[:port] */
             if ((p = strchr(optarg, ':'))) {
@@ -181,10 +160,10 @@ int main(int argc, char **argv)
             /*NOTREACHED*/
             break;
         case 'T':              /* --telemetry */
-            _cmd_create(commands, CP_TELEMETRY, NULL, true);
+            telemetry = true;
             break;
         case 'x':              /* --exprange */
-            _cmd_create(commands, CP_EXPRANGE, NULL, true);
+            exprange = true;
             break;
         case 'g':              /* --genders */
 #if WITH_GENDERS
@@ -192,9 +171,6 @@ int main(int argc, char **argv)
 #else
             err_exit(false, "not configured with genders support");
 #endif
-            break;
-        case 'Z':              /* --dump-cmds */
-            dumpcmds = true;
             break;
         case 'R':              /* --retry-connect=N (sleep 100ms after fail) */
             errno = 0;
@@ -208,43 +184,35 @@ int main(int argc, char **argv)
             break;
         }
     }
-    if (list_is_empty(commands))
-        _usage();
-
-    /* For backwards compat with powerman 2.0 and earlier,
-     * additional arguments are more targets for last command.
+    if (!command)
+        err_exit(false, "No action was specified.");
+    /* Combine free arguments into target hostlist.
+     * If --genders was selected, convert to hosts.
+     * Then convert back to a single hostlist-compressed argument.
+     * If there were no arguments, the result is the empty string.
      */
-    if (optind < argc) {
-        cmd_t *last = NULL;
-
-        itr = list_iterator_create(commands);
-        while ((cp = list_next(itr)))
-            last = cp;
-        list_iterator_destroy(itr);
-        if (last == NULL)
-            _usage();
-        while (optind < argc) {
-            _cmd_append(last, argv[optind]);
-            optind++;
+    while (optind < argc) {
+        if (!genders) {
+            if (!hostlist_push(targets, argv[optind++]))
+                err_exit(false, "hostlist error");
         }
+#if WITH_GENDERS
+        else
+            _push_genders_hosts(targets, argv[optind++]);
+#endif
     }
+    char argument[CP_LINEMAX];
+    if (hostlist_ranged_string(targets, sizeof(argument), argument) == -1)
+        err_exit(false, "hostlist error");
 
-    /* Prepare commands for processing.
+    /* Now that free arguments have been processed,
+     * Fail if 'command' doesn't accept an argument (%s) but there is one,
+     * or if the command requires an argument and there isn't one.
      */
-    itr = list_iterator_create(commands);
-    while ((cp = list_next(itr)))
-        _cmd_prepare(cp, genders);
-    list_iterator_destroy(itr);
-
-    /* Dump commands and exit if requested.
-     */
-    if (dumpcmds) {
-        itr = list_iterator_create(commands);
-        while ((cp = list_next(itr)))
-            _cmd_print(cp);
-        list_iterator_destroy(itr);
-        exit(0);
-    }
+    if (!strstr(command, "%s") && strlen (argument) > 0) // e.g. --nodes
+        err_exit(false, "Command does not accept targets");
+    if (targets_required && strlen (argument) == 0)
+        err_exit(false, "Command requires targets");
 
     /* Establish connection to server and start protocol.
      */
@@ -252,19 +220,37 @@ int main(int argc, char **argv)
     _process_version(server_fd);
     _expect(server_fd, CP_PROMPT);
 
-    /* Execute the commands.
+    /* First send commands that set options.
      */
-    itr = list_iterator_create(commands);
-    while ((cp = list_next(itr))) {
-        res = _cmd_execute(cp, server_fd);
+    if (telemetry) {
+        hfdprintf(server_fd, "%s%s" , CP_TELEMETRY, CP_EOL);
+        res = _process_response(server_fd);
+        _expect(server_fd, CP_PROMPT);
         if (res != 0)
-            break;
+            goto done;
     }
-    list_iterator_destroy(itr);
-    list_destroy(commands);
+    if (exprange) {
+        hfdprintf(server_fd, "%s%s", CP_EXPRANGE, CP_EOL);
+        res = _process_response(server_fd);
+        _expect(server_fd, CP_PROMPT);
+        if (res != 0)
+            goto done;
+    }
+    /* Send the main command.
+     * Use 'command' as the format string if it contains '%s' for an argument.
+     */
+    if (strstr (command, "%s")) {
+        hfdprintf(server_fd, command, argument);
+        hfdprintf(server_fd, CP_EOL);
+    }
+    else
+        hfdprintf(server_fd, "%s%s", command, CP_EOL);
+    res = _process_response(server_fd);
+    _expect(server_fd, CP_PROMPT);
 
     /* Disconnect from server.
      */
+done:
     hfdprintf(server_fd, "%s%s", CP_QUIT, CP_EOL);
     _expect(server_fd, CP_RSP_QUIT);
 
@@ -275,34 +261,32 @@ int main(int argc, char **argv)
  */
 static void _usage(void)
 {
-    printf("Usage: %s [action] [targets]\n", prog);
-    printf("  -1,--on targets      Power on targets\n");
-    printf("  -0,--off targets     Power off targets\n");
-    printf("  -c,--cycle targets   Power cycle targets\n");
-    printf("  -q,--query-all       Query power state of all targets\n");
-    printf("  -Q,--query targets   Query power state of specific targets\n");
+    printf("Usage: %s [options] [command] [targets]\n", prog);
+    printf(
+"Commands:\n"
+"  -1,--on              Power on targets\n"
+"  -0,--off             Power off targets\n"
+"  -c,--cycle           Power cycle targets\n"
+"  -q,--query           Query power state on optional targets\n"
+"  -r,--reset           Assert hardware reset on targets\n"
+"  -f,--flash           Turn beacon on on targets\n"
+"  -u,--unflash         Turn beacon off on targets\n"
+"  -b,--beacon          Query beacon status on optional targets\n"
+"  -P,--temp            Query temperature on optional targets\n"
+"  -l,--list            List available targets\n"
+"  -d,--device          Show status on optional device targets\n"
+"Options:\n"
 #if WITH_GENDERS
-    printf("  -g,--genders         Interpret targets as attributes\n");
+"  -g,--genders         Interpret targets as attributes\n"
 #endif
-    printf("  -h,--server-host host[:port]  Connect to remote server\n");
-    printf("  -x,--exprange        Expand host ranges in query response\n");
-    printf("  -l,--list            List available targets\n");
-    printf("  -V,--version         Show powerman version\n");
-    printf("  -L,--license         Show powerman license\n");
-    printf ("The following are not implemented by all devices:\n");
-    printf("  -r,--reset targets   Assert hardware reset\n");
-    printf("  -f,--flash targets   Turn beacon on\n");
-    printf("  -u,--unflash targets Turn beacon off\n");
-    printf("  -B,--beacon targets  Query beacon status of targets\n");
-    printf("  -b,--beacon-all      Query beacon status of all targets\n");
-    printf("  -P,--temp targets    Query temperature\n");
-    printf("  -t,--temp-all        Query temperature of all targets\n");
-    printf ("For testing/debugging:\n");
-    printf("  -T,--telemtery       Show device conversation for debugging\n");
-    printf("  -R,--retry-connect=N Retry connect to server up to N times\n");
-    printf("  -Z,--dump-cmds       Show powerman protocol requests and exit\n");
-    printf("  -D,--device=NAME     Show statistics of device NAME\n");
-    printf("  -d,--device-all      Show statistics of all devices\n");
+"  -h,--server-host host[:port]\n"
+"                       Connect to remote server\n"
+"  -x,--exprange        Expand host ranges in query response\n"
+"  -V,--version         Show powerman version\n"
+"  -L,--license         Show powerman license\n"
+"  -T,--telemtery       Show device conversation for debugging\n"
+"  -R,--retry-connect=N Retry connect to server up to N times\n"
+    );
     exit(1);
 }
 
@@ -327,6 +311,13 @@ static void _version(void)
 {
     printf("%s\n", PACKAGE_VERSION);
     exit(1);
+}
+
+static void _set_command (const char **command, const char *value)
+{
+    if (*command)
+        err_exit(false, "%s conflicts with %s", value, *command);
+    *command = value;
 }
 
 #if WITH_GENDERS
@@ -355,107 +346,6 @@ static void _push_genders_hosts(hostlist_t targets, char *s)
     }
 }
 #endif
-
-static void _cmd_create(List cl, char *fmt, char *arg, bool prepend)
-{
-    cmd_t *cp = (cmd_t *)xmalloc(sizeof(cmd_t));
-
-    cp->magic = CMD_MAGIC;
-    cp->fmt = fmt;
-    cp->argv = NULL;
-    cp->sendstr = NULL;
-    if (arg)
-        cp->argv = argv_create(arg, "");
-    if (prepend)
-        list_prepend(cl, cp);
-    else
-        list_append(cl, cp);
-}
-
-static void _cmd_destroy(cmd_t *cp)
-{
-    assert(cp->magic == CMD_MAGIC);
-
-    cp->magic = 0;
-    if (cp->sendstr)
-        xfree(cp->sendstr);
-    if (cp->argv)
-        argv_destroy(cp->argv);
-    xfree(cp);
-}
-
-static void _cmd_append(cmd_t *cp, char *arg)
-{
-    assert(cp->magic == CMD_MAGIC);
-    if (cp->argv == NULL) {
-        if (!strcmp(cp->fmt, CP_STATUS_ALL)) {
-            cp->fmt = CP_STATUS;
-            cp->argv = argv_create(arg, "");
-        } else if (!strcmp(cp->fmt, CP_BEACON_ALL)) {
-            cp->fmt = CP_BEACON;
-            cp->argv = argv_create(arg, "");
-        } else if (!strcmp(cp->fmt, CP_DEVICE_ALL)) {
-            cp->fmt = CP_DEVICE;
-            cp->argv = argv_create(arg, "");
-        } else if (!strcmp(cp->fmt, CP_TEMP_ALL)) {
-            cp->fmt = CP_TEMP;
-            cp->argv = argv_create(arg, "");
-        } else
-            err_exit(false, "option takes no arguments");
-    } else
-        cp->argv = argv_append(cp->argv, arg);
-}
-
-static void _cmd_prepare(cmd_t *cp, bool genders)
-{
-    char tmpstr[CP_LINEMAX];
-    hostlist_t hl;
-    int i;
-
-    assert(cp->magic == CMD_MAGIC);
-    assert(cp->sendstr == NULL);
-
-    tmpstr[0] = '\0';
-    if (cp->argv) {
-        hl = hostlist_create(NULL);
-        for (i = 0; i < argv_length(cp->argv); i++) {
-            if (genders) {
-#if WITH_GENDERS
-                _push_genders_hosts(hl, cp->argv[i]);
-#endif
-            } else {
-                if (hostlist_push(hl, cp->argv[i]) == 0)
-                    err_exit(false, "hostlist error");
-            }
-        }
-        if (hostlist_ranged_string(hl, sizeof(tmpstr), tmpstr) == -1)
-            err_exit(false, "hostlist error");
-        hostlist_destroy(hl);
-    }
-    cp->sendstr = hsprintf(cp->fmt, tmpstr);
-}
-
-static int _cmd_execute(cmd_t *cp, int fd)
-{
-    int res;
-
-    assert(cp->magic == CMD_MAGIC);
-    assert(cp->sendstr != NULL);
-
-    hfdprintf(fd, "%s%s", cp->sendstr, CP_EOL);
-    res = _process_response(fd);
-    _expect(fd, CP_PROMPT);
-
-    return res;
-}
-
-static void _cmd_print(cmd_t *cp)
-{
-    assert(cp->magic == CMD_MAGIC);
-    assert(cp->sendstr != NULL);
-
-    printf("%s%s", cp->sendstr, CP_EOL);
-}
 
 static int _connect_any(struct addrinfo *addr)
 {

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -56,7 +56,7 @@ static void _set_command (const char **command, const char *value);
 
 static char *prog;
 
-#define OPTIONS "01crfubqtldTxgh:VLR:"
+#define OPTIONS "01crfubqtldTxgh:VLR:H"
 static const struct option longopts[] = {
     // command
     {"on",          no_argument,        0, '1'},
@@ -78,6 +78,7 @@ static const struct option longopts[] = {
     {"version",     no_argument,        0, 'V'},
     {"license",     no_argument,        0, 'L'},
     {"retry-connect", required_argument, 0, 'R'},
+    {"help",        no_argument,        0, 'H'},
     {0, 0, 0, 0},
 };
 
@@ -178,8 +179,12 @@ int main(int argc, char **argv)
             if (errno != 0 || retry_connect < 1)
                 err_exit(false, "invalid --retry-connect argument");
             break;
-        default:
+        case 'H':              /* --help */
             _usage();
+            /*NOTREACHED*/
+        default:
+            err_exit(false,
+                     "Unknown option.  Try '--help' for more information.");
             /*NOTREACHED*/
             break;
         }
@@ -287,7 +292,7 @@ static void _usage(void)
 "  -T,--telemtery       Show device conversation for debugging\n"
 "  -R,--retry-connect=N Retry connect to server up to N times\n"
     );
-    exit(1);
+    exit(0);
 }
 
 /* Display powerman license and exit.

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -13,9 +13,7 @@
 #endif
 #include <stdio.h>
 #include <string.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #if HAVE_GENDERS_H
 #include <genders.h>
 #endif
@@ -72,8 +70,6 @@ static void _cmd_print(cmd_t *cp);
 static char *prog;
 
 #define OPTIONS "0:1:c:r:f:u:B:blQ:qP:tD:dTxgh:VLZR:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     {"on",          required_argument,  0, '1'},
     {"off",         required_argument,  0, '0'},
@@ -100,9 +96,6 @@ static const struct option longopts[] = {
     {"retry-connect", required_argument, 0, 'R'},
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int main(int argc, char **argv)
 {
@@ -125,7 +118,7 @@ int main(int argc, char **argv)
     /* Parse options.
      */
     opterr = 0;
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
         case '1':              /* --on */
             _cmd_create(commands, CP_ON, optarg, false);

--- a/src/powerman/powerman.c
+++ b/src/powerman/powerman.c
@@ -307,7 +307,7 @@ static void _license(void)
  "For details, see https://github.com/chaos/powerman.\n"
  "\n"
  "SPDX-License-Identifier: GPL-2.0-or-later\n");
-    exit(1);
+    exit(0);
 }
 
 /* Display powerman version and exit.
@@ -315,7 +315,7 @@ static void _license(void)
 static void _version(void)
 {
     printf("%s\n", PACKAGE_VERSION);
-    exit(1);
+    exit(0);
 }
 
 static void _set_command (const char **command, const char *value)

--- a/src/powerman/powermand.c
+++ b/src/powerman/powermand.c
@@ -15,9 +15,7 @@
 #include <errno.h>
 #include <sys/time.h>
 #include <time.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <signal.h>
 #include <string.h>
@@ -49,8 +47,6 @@ static void _exit_handler(int signum);
 static void _select_loop(void);
 
 #define OPTIONS "c:fhd:VsY"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     {"conf",            required_argument,  0, 'c'},
     {"foreground",      no_argument,        0, 'f'},
@@ -61,9 +57,6 @@ static const struct option longopts[] = {
     {"short-circuit-delay", no_argument,    0, 'Y'},
     {0, 0, 0, 0}
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int main(int argc, char **argv)
 {
@@ -75,7 +68,7 @@ int main(int argc, char **argv)
 
     /* parse command line options */
     err_init(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
         case 'Y': /* --short-circuit-delay */
             short_circuit_delay = true;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -40,7 +40,8 @@ TESTSCRIPTS = \
 	t0028-issues.t \
 	t0029-redfish.t \
 	t0030-heartbeat-stonith.t \
-	t0031-llnl-mcr-cluster.t
+	t0031-llnl-mcr-cluster.t \
+	t0032-list.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/simulators/baytech.c
+++ b/t/simulators/baytech.c
@@ -14,9 +14,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -41,16 +39,10 @@ typedef enum { NONE, RPC3, RPC3_NC, RPC28_NC, RPC3_DE } baytype_t;
 static char *prog;
 
 #define OPTIONS "p:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     { "personality", required_argument, 0, 'p' },
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
-
 
 int
 main(int argc, char *argv[])
@@ -59,7 +51,7 @@ main(int argc, char *argv[])
     baytype_t personality = NONE;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'p':
                 if (strcmp(optarg, "rpc3") == 0)

--- a/t/simulators/cyclades.c
+++ b/t/simulators/cyclades.c
@@ -14,9 +14,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -39,15 +37,10 @@ static char *prog;
 static cytype_t personality = NONE;
 
 #define OPTIONS "p:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     { "personality", required_argument, 0, 'p' },
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int
 main(int argc, char *argv[])
@@ -55,7 +48,7 @@ main(int argc, char *argv[])
     int c;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'p':
                 if (strcmp(optarg, "pm8") == 0)

--- a/t/simulators/icebox.c
+++ b/t/simulators/icebox.c
@@ -14,9 +14,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -39,16 +37,10 @@ static icetype_t personality = NONE;
 static char *prog;
 
 #define OPTIONS "p:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     { "personality", required_argument, 0, 'p' },
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
-
 
 int
 main(int argc, char *argv[])
@@ -56,7 +48,7 @@ main(int argc, char *argv[])
     int c;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'p':
                 if (strcmp(optarg, "v2") == 0)

--- a/t/simulators/ilom.c
+++ b/t/simulators/ilom.c
@@ -12,9 +12,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <stdio.h>
 #include <libgen.h>
 #include <ctype.h>
@@ -106,15 +104,10 @@ static ilomtype_t personality = NONE;
 static char *prog;
 
 #define OPTIONS "p:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     { "personality", required_argument, 0, 'p' },
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int
 main(int argc, char *argv[])
@@ -122,7 +115,7 @@ main(int argc, char *argv[])
     int c;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'p':
                 if (strcmp(optarg, "ssh") == 0)

--- a/t/simulators/ipmipower.c
+++ b/t/simulators/ipmipower.c
@@ -37,9 +37,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -63,16 +61,11 @@ static char *hostname = NULL;
 static int auth_failure = 0;
 
 #define OPTIONS "h:A"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     { "hostname", required_argument, 0, 'h' },
     { "auth-failure", no_argument, 0, 'A' },
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int
 main(int argc, char *argv[])
@@ -80,7 +73,7 @@ main(int argc, char *argv[])
     int c;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'h':
                 hostname = optarg;

--- a/t/simulators/lom.c
+++ b/t/simulators/lom.c
@@ -12,9 +12,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <stdio.h>
 #include <libgen.h>
 #include <ctype.h>
@@ -49,15 +47,10 @@ static ilomtype_t personality = NONE;
 static char *prog;
 
 #define OPTIONS "p:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     { "personality", required_argument, 0, 'p' },
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int
 main(int argc, char *argv[])
@@ -65,7 +58,7 @@ main(int argc, char *argv[])
     int c;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'p':
                 if (strcmp(optarg, "ssh") == 0)

--- a/t/simulators/redfishpower.c
+++ b/t/simulators/redfishpower.c
@@ -14,9 +14,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -41,15 +39,10 @@ static char *hostname = NULL;
 /* we only support -h here, assuming user will configure all
  * paths/postdata via prompt */
 #define OPTIONS "h:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     { "hostname", required_argument, 0, 'h' },
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int
 main(int argc, char *argv[])
@@ -57,7 +50,7 @@ main(int argc, char *argv[])
     int c;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'h':
                 hostname = optarg;

--- a/t/simulators/swpdu.c
+++ b/t/simulators/swpdu.c
@@ -16,9 +16,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -38,15 +36,9 @@ static void _prompt_loop(void);
 static char *prog;
 
 #define OPTIONS "p:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
-
 
 int
 main(int argc, char *argv[])
@@ -54,7 +46,7 @@ main(int argc, char *argv[])
     int c;
 
     prog = basename(argv[0]);
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             default:
                 usage();

--- a/t/simulators/vpcd.c
+++ b/t/simulators/vpcd.c
@@ -12,9 +12,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#if HAVE_GETOPT_H
 #include <getopt.h>
-#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -46,15 +44,10 @@ static int logged_in = 0;
 static char *prog;
 
 #define OPTIONS "p:"
-#if HAVE_GETOPT_LONG
-#define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
     {"port", required_argument, 0, 'p'},
     {0, 0, 0, 0},
 };
-#else
-#define GETOPT(ac,av,opt,lopt) getopt(ac,av,opt)
-#endif
 
 int
 main(int argc, char *argv[])
@@ -64,7 +57,7 @@ main(int argc, char *argv[])
 
     prog = basename(argv[0]);
 
-    while ((c = GETOPT(argc, argv, OPTIONS, longopts)) != -1) {
+    while ((c = getopt_long(argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (c) {
             case 'p':   /* --port n */
                 port = xstrdup(optarg);

--- a/t/t0001-powerman-client.t
+++ b/t/t0001-powerman-client.t
@@ -6,15 +6,16 @@ test_description='Test Powerman Client without server'
 
 powerman=$SHARNESS_BUILD_DIRECTORY/src/powerman/powerman
 
-test_expect_success 'powerman -h fails with usage on stdout' '
-	test_must_fail $powerman -h >help.out &&
-	grep -q Usage: help.out
+test_expect_success 'powerman --help displays usage' '
+	$powerman --help >help.out &&
+	grep Usage: help.out
 '
 
-test_expect_success 'powerman --badopt fails with usage on stdout' '
-	test_must_fail $powerman --badopt >badopt.out &&
-	grep -q Usage: badopt.out
+test_expect_success 'powerman --badopt fails with error on stderr' '
+	test_must_fail $powerman --badopt 2>badopt.out &&
+	grep "Unknown option" badopt.out
 '
+
 test_done
 
 # vi: set ft=sh

--- a/t/t0001-powerman-client.t
+++ b/t/t0001-powerman-client.t
@@ -16,6 +16,20 @@ test_expect_success 'powerman --badopt fails with error on stderr' '
 	grep "Unknown option" badopt.out
 '
 
+test_expect_success 'powerman without an action fails with message on stderr' '
+	test_must_fail $powerman -T 2>noaction.err &&
+	grep "No action was specified" noaction.err
+'
+
+test_expect_success 'powerman --version works' '
+	$powerman --version >version.out &&
+	test $(wc -l <version.out) -eq 1
+'
+test_expect_success 'powerman --license works' '
+	$powerman --license >license.out &&
+	grep GPL license.out
+'
+
 test_done
 
 # vi: set ft=sh

--- a/t/t0004-status-query.t
+++ b/t/t0004-status-query.t
@@ -37,25 +37,20 @@ test_expect_success 'powerman -q works' '
 	makeoutput "" "t[0-15]" "" >query.exp &&
 	test_cmp query.exp query.out
 '
-test_expect_success 'powerman -Q t1 works' '
-	$powerman -h $testaddr -Q t1 >query2.out &&
+test_expect_success 'powerman -q t1 works' '
+	$powerman -h $testaddr -q t1 >query2.out &&
 	makeoutput "" "t1" "" >query2.exp &&
 	test_cmp query2.exp query2.out
 '
-test_expect_success 'powerman -Q t[3-5] works' '
-	$powerman -h $testaddr -Q t[3-5] >query3.out &&
-	makeoutput "" "t[3-5]" "" >query3.exp &&
-	test_cmp query3.exp query3.out
+test_expect_success 'powerman -q t1 t2 works' '
+	$powerman -h $testaddr -q t1 t2 >query2a.out &&
+	makeoutput "" "t[1-2]" "" >query2a.exp &&
+	test_cmp query2.exp query2.out
 '
 test_expect_success 'powerman -q t[3-5] works' '
-	$powerman -h $testaddr -q t[3-5] >query3b.out &&
-	makeoutput "" "t[3-5]" "" >query3b.exp &&
-	test_cmp query3b.exp query3b.out
-'
-test_expect_success 'powerman -Q t1 t2 works' '
-	$powerman -h $testaddr -Q t1 t2 >query4.out &&
-	makeoutput "" "t[1-2]" "" >query4.exp &&
-	test_cmp query4.exp query4.out
+	$powerman -h $testaddr -q t[3-5] >query3.out &&
+	makeoutput "" "t[3-5]" "" >query3.exp &&
+	test_cmp query3.exp query3.out
 '
 test_expect_success 'stop powerman daemon' '
 	kill -15 $(cat powermand.pid) &&
@@ -99,13 +94,13 @@ test_expect_success 'powerman -q works' '
 	makeoutput "" "t[0-15]" "" >nsa_query.exp &&
 	test_cmp nsa_query.exp nsa_query.out
 '
-test_expect_success 'powerman -Q t1 works' '
-	$powerman -h $testaddr -Q t1 >nsa_query2.out &&
+test_expect_success 'powerman -q t1 works' '
+	$powerman -h $testaddr -q t1 >nsa_query2.out &&
 	makeoutput "" "t1" "" >nsa_query2.exp &&
 	test_cmp nsa_query2.exp nsa_query2.out
 '
-test_expect_success 'powerman -Q t[3-5] works' '
-	$powerman -h $testaddr -Q t[3-5] >nsa_query3.out &&
+test_expect_success 'powerman -q t[3-5] works' '
+	$powerman -h $testaddr -q t[3-5] >nsa_query3.out &&
 	makeoutput "" "t[3-5]" "" >nsa_query3.exp &&
 	test_cmp nsa_query3.exp nsa_query3.out
 '
@@ -134,13 +129,13 @@ test_expect_success 'powerman -q works' '
 	makeoutput "" "t[0-15]" "" >tcp_query.exp &&
 	test_cmp tcp_query.exp tcp_query.out
 '
-test_expect_success 'powerman -Q t1 works' '
-	$powerman -h $testaddr -Q t1 >tcp_query2.out &&
+test_expect_success 'powerman -q t1 works' '
+	$powerman -h $testaddr -q t1 >tcp_query2.out &&
 	makeoutput "" "t1" "" >tcp_query2.exp &&
 	test_cmp tcp_query2.exp tcp_query2.out
 '
-test_expect_success 'powerman -Q t[3-5] works' '
-	$powerman -h $testaddr -Q t[3-5] >tcp_query3.out &&
+test_expect_success 'powerman -q t[3-5] works' '
+	$powerman -h $testaddr -q t[3-5] >tcp_query3.out &&
 	makeoutput "" "t[3-5]" "" >tcp_query3.exp &&
 	test_cmp tcp_query3.exp tcp_query3.out
 '

--- a/t/t0006-on-off-cycle.t
+++ b/t/t0006-on-off-cycle.t
@@ -67,6 +67,28 @@ test_expect_success 'powerman -q shows t5 on' '
 	makeoutput "t5" "t[0-4,6-15]" "" >query4.exp &&
 	test_cmp query4.exp query4.out
 '
+test_expect_success 'powerman -1 t14 t15 works' '
+	$powerman -h $testaddr -1 t14 t15 >on5.out &&
+	echo "Command completed successfully" >on5.exp
+'
+test_expect_success 'powerman -q shows t14 t15 on' '
+	$powerman -h $testaddr -q >query5.out &&
+	makeoutput "t[5,14-15]" "t[0-4,6-13]" "" >query5.exp &&
+	test_cmp query5.exp query5.out
+'
+test_expect_success 'powerman -1 with no targets fails with useful error' '
+	test_must_fail $powerman -h $testaddr -1 2>notargets1.err &&
+	grep "Command requires targets" notargets1.err
+'
+test_expect_success 'powerman -0 with no targets fails with useful error' '
+	test_must_fail $powerman -h $testaddr -0 2>notargets0.err &&
+	grep "Command requires targets" notargets0.err
+'
+test_expect_success 'powerman -c with no targets fails with useful error' '
+	test_must_fail $powerman -h $testaddr -c 2>notargetsc.err &&
+	grep "Command requires targets" notargetsc.err
+'
+
 test_expect_success 'stop powerman daemon' '
 	kill -15 $(cat powermand.pid) &&
 	wait

--- a/t/t0007-temperature.t
+++ b/t/t0007-temperature.t
@@ -48,13 +48,13 @@ test_expect_success 'powerman -t works' '
 	EOT
 	test_cmp query_all.exp query_all.out
 '
-test_expect_success 'powerman -P t13 works' '
-	$powerman -h $testaddr -P t13 >query_t13.out &&
+test_expect_success 'powerman -t t13 works' '
+	$powerman -h $testaddr -t t13 >query_t13.out &&
 	echo "t13: 96" >query_t13.exp &&
 	test_cmp query_t13.exp query_t13.out
 '
-test_expect_success 'powerman -P t[13-15] works' '
-	$powerman -h $testaddr -P t[13-15] >query_set.out &&
+test_expect_success 'powerman -t t[13-15] works' '
+	$powerman -h $testaddr -t t[13-15] >query_set.out &&
 	cat >query_set.exp <<-EOT &&
 	t13: 96
 	t14: 97

--- a/t/t0008-beacon.t
+++ b/t/t0008-beacon.t
@@ -57,15 +57,23 @@ test_expect_success 'powerman -b shows beacons t[14-15] on' '
 	makeoutput "t[14-15]" "t[0-13]" "" >query3.exp &&
 	test_cmp query3.exp query3.out
 '
-test_expect_success 'powerman -B t13 shows beacon t13 off' '
-	$powerman -h $testaddr -B t13 >query4.out &&
+test_expect_success 'powerman -b t13 shows beacon t13 off' '
+	$powerman -h $testaddr -b t13 >query4.out &&
 	makeoutput "" "t13" "" >query4.exp &&
 	test_cmp query4.exp query4.out
 '
-test_expect_success 'powerman -B t14 shows beacon t14 on' '
-	$powerman -h $testaddr -B t14 >query5.out &&
+test_expect_success 'powerman -b t14 shows beacon t14 on' '
+	$powerman -h $testaddr -b t14 >query5.out &&
 	makeoutput "t14" "" "" >query5.exp &&
 	test_cmp query5.exp query5.out
+'
+test_expect_success 'powerman -f with no targets fails with useful error' '
+	test_must_fail $powerman -h $testaddr -f 2>notargetsf.err &&
+	grep "Command requires targets" notargetsf.err
+'
+test_expect_success 'powerman -u with no targets fails with useful error' '
+	test_must_fail $powerman -h $testaddr -u 2>notargetsu.err &&
+	grep "Command requires targets" notargetsu.err
 '
 test_expect_success 'stop powerman daemon' '
 	kill -15 $(cat powermand.pid) &&

--- a/t/t0009-reset.t
+++ b/t/t0009-reset.t
@@ -36,6 +36,10 @@ test_expect_success 'powerman -r t[3-5] works' '
 	echo "Command completed successfully" >reset2.exp &&
 	test_cmp reset2.exp reset2.out
 '
+test_expect_success 'powerman -r with no targets fails with useful error' '
+        test_must_fail $powerman -h $testaddr -r 2>notargets.err &&
+        grep "Command requires targets" notargets.err
+'
 test_expect_success 'stop powerman daemon' '
 	kill -15 $(cat powermand.pid) &&
 	wait

--- a/t/t0010-device-status.t
+++ b/t/t0010-device-status.t
@@ -31,16 +31,16 @@ test_expect_success 'powerman -d works' '
 	echo "test0: state=connected reconnects=000 actions=002 type=vpc hosts=t[0-15]" >device.exp &&
 	test_cmp device.exp device.out
 '
-test_expect_success 'run powerman -Q t1' '
-	$powerman -h $testaddr -Q t1 >/dev/null
+test_expect_success 'run powerman -q t1' '
+	$powerman -h $testaddr -q t1 >/dev/null
 '
 test_expect_success 'powerman -d shows additional action' '
 	$powerman -h $testaddr -d >device2.out &&
 	echo "test0: state=connected reconnects=000 actions=003 type=vpc hosts=t[0-15]" >device2.exp &&
 	test_cmp device2.exp device2.out
 '
-test_expect_success 'running powerman -D t1 returns the same thing' '
-	$powerman -h $testaddr -D t1 >device3.out &&
+test_expect_success 'running powerman -d t1 returns the same thing' '
+	$powerman -h $testaddr -d t1 >device3.out &&
 	test_cmp device2.exp device3.out
 '
 # Should this be somewhere else?

--- a/t/t0011-device-timeout.t
+++ b/t/t0011-device-timeout.t
@@ -75,8 +75,8 @@ test_expect_success 'start powerman daemon and wait for it to start' '
 	echo $! >powermand.pid &&
 	$powerman --retry-connect=100 --server-host=$testaddr -d
 '
-test_expect_success 'powerman -Q t[14-18] times out' '
-	test_must_fail $powerman -h $testaddr -Q t[14-18] >query2.out
+test_expect_success 'powerman -q t[14-18] times out' '
+	test_must_fail $powerman -h $testaddr -q t[14-18] >query2.out
 '
 test_expect_success 'and command partially succeeded' '
 	echo test0: action timed out waiting for expected response \
@@ -85,8 +85,8 @@ test_expect_success 'and command partially succeeded' '
 	echo Query completed with errors >>query2.exp &&
 	test_cmp query2.exp query2.out
 '
-test_expect_success 'powerman -Q t[16-31] works' '
-	$powerman -h $testaddr -Q t[16-31] >query3.out &&
+test_expect_success 'powerman -q t[16-31] works' '
+	$powerman -h $testaddr -q t[16-31] >query3.out &&
 	makeoutput "" "t[16-31]" "" >query3.exp &&
 	test_cmp query3.exp query3.out
 '

--- a/t/t0026-llnl-sierra-cluster.t
+++ b/t/t0026-llnl-sierra-cluster.t
@@ -85,14 +85,14 @@ test_expect_success 'start powerman daemon and wait for it to start' '
 	echo $! >powermand.pid &&
 	$powerman --retry-connect=100 --server-host=$testaddr -d >device.out
 '
-test_expect_success 'powerman -Q sierra[0,2-1943] shows all blades off' '
-	$powerman -h $testaddr -Q sierra[0,2-1943] >query_blades.out &&
+test_expect_success 'powerman -q sierra[0,2-1943] shows all blades off' '
+	$powerman -h $testaddr -q sierra[0,2-1943] >query_blades.out &&
 	makeoutput "" "sierra[0,2-1943]" "" >query_blades.exp &&
 	test_cmp query_blades.exp query_blades.out
 '
 # Messy off: line so just verify that "unknown" and "on" are empty
-test_expect_success 'powerman -Q chassis[1-468] shows all chassis off' '
-	$powerman -h $testaddr -Q chassis[1-468] >query_chassis.out &&
+test_expect_success 'powerman -q chassis[1-468] shows all chassis off' '
+	$powerman -h $testaddr -q chassis[1-468] >query_chassis.out &&
 	grep -q "unknown: $" query_chassis.out &&
 	grep -q "on:      $" query_chassis.out
 '
@@ -101,8 +101,8 @@ test_expect_success 'powerman -1 chassis[1-468] works' '
 	echo Command completed successfully >on_chassis.exp &&
 	test_cmp on_chassis.exp on_chassis.out
 '
-test_expect_success 'powerman -Q chassis[1-468] shows all chassis on' '
-	$powerman -h $testaddr -Q chassis[1-468] >query_chassis2.out &&
+test_expect_success 'powerman -q chassis[1-468] shows all chassis on' '
+	$powerman -h $testaddr -q chassis[1-468] >query_chassis2.out &&
 	grep -q "unknown: $" query_chassis2.out &&
 	grep -q "off:     $" query_chassis2.out
 '
@@ -111,8 +111,8 @@ test_expect_success 'powerman -1 sierra[0,2-1943] works' '
 	echo Command completed successfully >on_blades.exp &&
 	test_cmp on_blades.exp on_blades.out
 '
-test_expect_success 'powerman -Q sierra[0,2-1943] shows all blades on' '
-	$powerman -h $testaddr -Q sierra[0,2-1943] >query_blades2.out &&
+test_expect_success 'powerman -q sierra[0,2-1943] shows all blades on' '
+	$powerman -h $testaddr -q sierra[0,2-1943] >query_blades2.out &&
 	makeoutput "sierra[0,2-1943]" "" "" >query_blades2.exp &&
 	test_cmp query_blades2.exp query_blades2.out
 '
@@ -121,8 +121,8 @@ test_expect_success 'powerman -0 sierra[0,2-1943] works' '
 	echo Command completed successfully >off_blades.exp &&
 	test_cmp off_blades.exp off_blades.out
 '
-test_expect_success 'powerman -Q sierra[0,2-1943] shows all blades off' '
-	$powerman -h $testaddr -Q sierra[0,2-1943] >query_blades3.out &&
+test_expect_success 'powerman -q sierra[0,2-1943] shows all blades off' '
+	$powerman -h $testaddr -q sierra[0,2-1943] >query_blades3.out &&
 	makeoutput "" "sierra[0,2-1943]" "" >query_blades3.exp &&
 	test_cmp query_blades3.exp query_blades3.out
 '
@@ -131,8 +131,8 @@ test_expect_success 'powerman -0 chassis[1-468] works' '
 	echo Command completed successfully >off_chassis.exp &&
 	test_cmp off_chassis.exp off_chassis.out
 '
-test_expect_success 'powerman -Q chassis[1-468] shows all chassis off' '
-	$powerman -h $testaddr -Q chassis[1-468] >query_chassis3.out &&
+test_expect_success 'powerman -q chassis[1-468] shows all chassis off' '
+	$powerman -h $testaddr -q chassis[1-468] >query_chassis3.out &&
 	grep -q "unknown: $" query_chassis3.out &&
 	grep -q "on:      $" query_chassis3.out
 '

--- a/t/t0032-list.t
+++ b/t/t0032-list.t
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+test_description='Test Powerman list query'
+
+. `dirname $0`/sharness.sh
+
+powermand=$SHARNESS_BUILD_DIRECTORY/src/powerman/powermand
+powerman=$SHARNESS_BUILD_DIRECTORY/src/powerman/powerman
+vpcd=$SHARNESS_BUILD_DIRECTORY/t/simulators/vpcd
+vpcdev=$SHARNESS_TEST_SRCDIR/etc/vpc.dev
+
+# Use port = 11000 + test number
+# That way there won't be port conflicts with make -j
+testaddr=localhost:11032
+
+test_expect_success 'create test powerman.conf' '
+	cat >powerman.conf <<-EOT
+	include "$vpcdev"
+	listen "$testaddr"
+	device "test0" "vpc" "$vpcd |&"
+	node "t[0-15]" "test0"
+	EOT
+'
+test_expect_success 'start powerman daemon and wait for it to start' '
+	$powermand -c powerman.conf -f &
+	echo $! >powermand.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -d >/dev/null
+'
+test_expect_success 'powerman -l works' '
+	$powerman -h $testaddr -l >list.out &&
+	echo "t[0-15]" >list.exp &&
+	test_cmp list.exp list.out
+'
+test_expect_success 'powerman -l fails with targets' '
+	test_must_fail $powerman -h $testaddr -l t2 2>list.err
+'
+test_expect_success 'and a useful message was printed on stderr' '
+	grep "does not accept targets" list.err
+'
+test_expect_success 'stop powerman daemon' '
+	kill -15 $(cat powermand.pid) &&
+	wait
+'
+test_done
+
+# vi: set ft=sh


### PR DESCRIPTION
Problem: the powerman client's option parsing is a mess due to the way the test suite used to work.

This removes some options that were "published" before, but they were only added to support the test suite, and I doubt people picked them up and used them as the original options were clearer.  Anyway, perhaps we can just call this out in the next release notes to give people a heads up.