### PR TITLE
systemd: run as Type=simple

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,6 @@ AC_CONFIG_FILES( \
   etc/Makefile \
   etc/libpowerman.pc \
   etc/powerman.service \
-  etc/tmpfiles.d/powerman.conf \
   heartbeat/Makefile \
   man/Makefile \
   man/powerman.1 \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,7 +1,5 @@
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = powerman.service
-systemdtmpdir_ddir = ${prefix}/lib/tmpfiles.d
-systemdtmpdir_d_DATA = tmpfiles.d/powerman.conf
 endif
 
 if WITH_PKG_CONFIG

--- a/etc/powerman.service.in
+++ b/etc/powerman.service.in
@@ -4,12 +4,10 @@ After=syslog.target network.target
 
 [Service]
 Environment=SHELL=/bin/sh
-Type=forking
 PrivateTmp=yes
 User=@RUN_AS_USER@
 Group=@RUN_AS_GROUP@
-ExecStart=@X_SBINDIR@/powermand
-PIDFile=@X_RUNSTATEDIR@/powerman/powermand.pid
+ExecStart=@X_SBINDIR@/powermand -f
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/tmpfiles.d/powerman.conf.in
+++ b/etc/tmpfiles.d/powerman.conf.in
@@ -1,1 +1,0 @@
-d @X_RUNSTATEDIR@/powerman   755 daemon daemon


### PR DESCRIPTION
Problem: powermand runs as a Type=forking systemd service, but Type=simple is recommended by systemd.service(5).

Switch to Type=simple (the default).

Drop the tmpfiles.d configuration which was for managing /run/powerman on systemd < v233 (now ancient).  Powerman doesn't need the rundir anyway when not running in daemon mode, since all it does is store a pidfile there.

Fixes #13

FWIW I tested this on a debian 12 system and it seems to work fine.