### PR TITLE
powermand: fix assertion failure on teardown

### DIFF
--- a/src/powerman/device.c
+++ b/src/powerman/device.c
@@ -1306,7 +1306,6 @@ void dev_destroy(Device * dev)
     int i;
 
     assert(dev->magic == DEV_MAGIC);
-    dev->magic = 0;
 
     if (dev->connect_state == DEV_CONNECTED)
         dev->disconnect(dev);
@@ -1327,6 +1326,7 @@ void dev_destroy(Device * dev)
     cbuf_destroy(dev->to);
     cbuf_destroy(dev->from);
     xregex_match_destroy(dev->xmatch);
+    dev->magic = 0;
     xfree(dev);
 }
 


### PR DESCRIPTION
Problem: an assertion failure is seen when powermand tears down with a tcp-connected device:

powermand: device_tcp.c:266: tcp_disconnect:
  Assertion `dev->magic == DEV_MAGIC' failed.

This is because dev_destroy sets dev->magic = 0 before it calls dev->disconnect.  When dev->disconnect points to tcp_disconnect() the assertion triggers.

Fixes #106