### PR TITLE
testsuite: add valgrind coverage

### DIFF
--- a/src/powerman/parse_tab.y
+++ b/src/powerman/parse_tab.y
@@ -86,7 +86,6 @@ static Spec *makeSpec(char *name);
 static Spec *findSpec(char *name);
 static int matchSpec(Spec * spec, void *key);
 static void destroySpec(Spec * spec);
-static void _clear_current_spec(void);
 static void makeScript(int com, List stmts);
 static void destroyInterp(Interp *i);
 static Interp *makeInterp(InterpState state, char *str);
@@ -365,7 +364,6 @@ int parse_config_file (char *filename)
         err_exit(true, "%s", filename);
 
     device_specs = list_create((ListDelF) destroySpec);
-    _clear_current_spec();
 
     yyparse();
     fclose(yyin);
@@ -416,18 +414,6 @@ static void destroyPreStmt(PreStmt *p)
     xfree(p);
 }
 
-static void _clear_current_spec(void)
-{
-    int i;
-
-    current_spec.name = NULL;
-    current_spec.plugs = NULL;
-    timerclear(&current_spec.timeout);
-    timerclear(&current_spec.ping_period);
-    for (i = 0; i < NUM_SCRIPTS; i++)
-        current_spec.prescripts[i] = NULL;
-}
-
 static Spec *_copy_current_spec(void)
 {
     Spec *new = (Spec *) xmalloc(sizeof(Spec));
@@ -436,7 +422,7 @@ static Spec *_copy_current_spec(void)
     *new = current_spec;
     for (i = 0; i < NUM_SCRIPTS; i++)
         new->prescripts[i] = current_spec.prescripts[i];
-    _clear_current_spec();
+    memset (&current_spec, 0, sizeof (current_spec));
     return new;
 }
 

--- a/src/powerman/parse_tab.y
+++ b/src/powerman/parse_tab.y
@@ -535,9 +535,11 @@ static void destroyStmt(Stmt *stmt)
         break;
     case STMT_FOREACHNODE:
     case STMT_FOREACHPLUG:
+        list_destroy(stmt->u.foreach.stmts);
+        break;
     case STMT_IFON:
     case STMT_IFOFF:
-        list_destroy(stmt->u.foreach.stmts);
+        list_destroy(stmt->u.ifonoff.stmts);
         break;
     default:
         break;

--- a/src/powerman/parse_tab.y
+++ b/src/powerman/parse_tab.y
@@ -417,11 +417,8 @@ static void destroyPreStmt(PreStmt *p)
 static Spec *_copy_current_spec(void)
 {
     Spec *new = (Spec *) xmalloc(sizeof(Spec));
-    int i;
 
     *new = current_spec;
-    for (i = 0; i < NUM_SCRIPTS; i++)
-        new->prescripts[i] = current_spec.prescripts[i];
     memset (&current_spec, 0, sizeof (current_spec));
     return new;
 }

--- a/src/powerman/parse_tab.y
+++ b/src/powerman/parse_tab.y
@@ -531,6 +531,7 @@ static void destroyStmt(Stmt *stmt)
         break;
     case STMT_SETPLUGSTATE:
         list_destroy(stmt->u.setplugstate.interps);
+        xfree (stmt->u.setplugstate.plug_name);
         break;
     case STMT_FOREACHNODE:
     case STMT_FOREACHPLUG:

--- a/src/powerman/parse_util.c
+++ b/src/powerman/parse_util.c
@@ -84,10 +84,8 @@ void conf_init(char *filename)
         err_exit(false, "%s is not a regular file\n", filename);
 
     /*
-     * Call yacc parser against config file.  The parser calls support
-     * functions below and builds 'dev_devices' (devices.c),
-     * 'conf_cluster', 'conf_specs' (config.c), and various other
-     * conf_* attributes (config.c).
+     * Call yacc parser against config file.
+     * The parser builds 'dev_devices' (devices.c) and 'conf_*' (here).
      */
     parse_config_file(filename);
 

--- a/src/powerman/parse_util.c
+++ b/src/powerman/parse_util.c
@@ -102,6 +102,8 @@ void conf_fini(void)
 {
     if (conf_nodes != NULL)
         hostlist_destroy(conf_nodes);
+    if (conf_listen != NULL)
+        list_destroy(conf_listen);
 }
 
 /*

--- a/src/powerman/parse_util.c
+++ b/src/powerman/parse_util.c
@@ -100,6 +100,8 @@ void conf_init(char *filename)
 /* finalize module */
 void conf_fini(void)
 {
+    if (conf_aliases != NULL)
+        list_destroy(conf_aliases);
     if (conf_nodes != NULL)
         hostlist_destroy(conf_nodes);
     if (conf_listen != NULL)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -41,7 +41,8 @@ TESTSCRIPTS = \
 	t0029-redfish.t \
 	t0030-heartbeat-stonith.t \
 	t0031-llnl-mcr-cluster.t \
-	t0032-list.t
+	t0032-list.t \
+	t0033-valgrind.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/t0033-valgrind.t
+++ b/t/t0033-valgrind.t
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+test_description='Test Powerman list query'
+
+. `dirname $0`/sharness.sh
+
+powermand=$SHARNESS_BUILD_DIRECTORY/src/powerman/powermand
+powerman=$SHARNESS_BUILD_DIRECTORY/src/powerman/powerman
+vpcd=$SHARNESS_BUILD_DIRECTORY/t/simulators/vpcd
+vpcdev=$SHARNESS_TEST_SRCDIR/etc/vpc.dev
+
+# Use port = 11000 + test number
+# That way there won't be port conflicts with make -j
+testaddr=localhost:11033
+
+if ! valgrind --version; then
+	skip_all='skipping valgrind tests'
+	test_done
+fi
+
+test_expect_success 'create test powerman.conf' '
+	cat >powerman.conf <<-EOT
+	include "$vpcdev"
+	listen "$testaddr"
+	device "test0" "vpc" "$vpcd |&"
+	node "t[0-15]" "test0"
+	alias "a0" "t0"
+	EOT
+'
+test_expect_failure 'run powermand --stdio under valgrind' '
+	valgrind --tool=memcheck --leak-check=full --error-exitcode=1 \
+	    $powermand --stdio -c powerman.conf 2>valgrind.err <<-EOT
+	help
+	EOT
+'
+test_done
+
+# vi: set ft=sh


### PR DESCRIPTION
This adds a valgrind test and fixes a few memory leaks but not all of them.The test currently is an expected failure, but it can be run with `-d` and the failures can be picked out of the trash.  I suppose we could merge this as is and pick off the rest of the leaks as time permits.  (I tried but didn't find anything obvious)

```
$ ./t0033-valgrind.t -d
valgrind-3.16.1
ok 1 - create test powerman.conf
not ok 2 - run powermand --stdio under valgrind # TODO known breakage
# still have 1 known breakage(s)
# passed all remaining 1 test(s)
1..2
$ cat trash-directory.t0033-valgrind/valgrind.err
==27863== Memcheck, a memory error detector
==27863== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27863== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==27863== Command: /nfshome/garlick/proj/powerman/t/../src/powerman/powermand --stdio -c powerman.conf
==27863== 
==27863== Warning: noted but unhandled ioctl 0x5441 with no size/direction hints.
==27863==    This could cause spurious value errors to appear.
==27863==    See README_MISSING_SYSCALL_OR_IOCTL for guidance on writing a proper wrapper.
powermand: _pipe_connect(test0): opened on /dev/pts/3
powermand: client poll: hangup
powermand: _pipe_disconnect(test0): /nfshome/garlick/proj/powerman/t/../t/simulators/vpcd terminated with signal 1
==27863== 
==27863== HEAP SUMMARY:
==27863==     in use at exit: 24,930 bytes in 15 blocks
==27863==   total heap usage: 1,995 allocs, 1,980 frees, 216,254 bytes allocated
==27863== 
==27863== 512 bytes in 1 blocks are possibly lost in loss record 4 of 13
==27863==    at 0x4849E4C: malloc (vg_replace_malloc.c:307)
==27863==    by 0x11A35B: list_alloc_aux (list.c:782)
==27863==    by 0x11A35B: list_node_alloc (list.c:738)
==27863==    by 0x11A35B: list_node_create (list.c:665)
==27863==    by 0x11423B: yyparse (parse_tab.y:219)
==27863==    by 0x114ABB: parse_config_file (parse_tab.y:368)
==27863==    by 0x114C43: conf_init (parse_util.c:90)
==27863==    by 0x10AE9F: main (powermand.c:124)
==27863== 
==27863== 512 bytes in 1 blocks are possibly lost in loss record 5 of 13
==27863==    at 0x4849E4C: malloc (vg_replace_malloc.c:307)
==27863==    by 0x11A35B: list_alloc_aux (list.c:782)
==27863==    by 0x11A35B: list_node_alloc (list.c:738)
==27863==    by 0x11A35B: list_node_create (list.c:665)
==27863==    by 0x113C7B: yyparse (parse_tab.y:292)
==27863==    by 0x114ABB: parse_config_file (parse_tab.y:368)
==27863==    by 0x114C43: conf_init (parse_util.c:90)
==27863==    by 0x10AE9F: main (powermand.c:124)
==27863== 
==27863== 512 bytes in 1 blocks are possibly lost in loss record 6 of 13
==27863==    at 0x4849E4C: malloc (vg_replace_malloc.c:307)
==27863==    by 0x11A35B: list_alloc_aux (list.c:782)
==27863==    by 0x11A35B: list_node_alloc (list.c:738)
==27863==    by 0x11A35B: list_node_create (list.c:665)
==27863==    by 0x113C43: yyparse (parse_tab.y:288)
==27863==    by 0x114ABB: parse_config_file (parse_tab.y:368)
==27863==    by 0x114C43: conf_init (parse_util.c:90)
==27863==    by 0x10AE9F: main (powermand.c:124)
==27863== 
==27863== 512 bytes in 1 blocks are possibly lost in loss record 7 of 13
==27863==    at 0x4849E4C: malloc (vg_replace_malloc.c:307)
==27863==    by 0x11A35B: list_alloc_aux (list.c:782)
==27863==    by 0x11A35B: list_node_alloc (list.c:738)
==27863==    by 0x11A35B: list_node_create (list.c:665)
==27863==    by 0x113103: makeDevice (parse_tab.y:685)
==27863==    by 0x114787: yyparse (parse_tab.y:176)
==27863==    by 0x114ABB: parse_config_file (parse_tab.y:368)
==27863==    by 0x114C43: conf_init (parse_util.c:90)
==27863==    by 0x10AE9F: main (powermand.c:124)
==27863== 
==27863== 512 bytes in 1 blocks are possibly lost in loss record 8 of 13
==27863==    at 0x4849E4C: malloc (vg_replace_malloc.c:307)
==27863==    by 0x11A35B: list_alloc_aux (list.c:782)
==27863==    by 0x11A35B: list_node_alloc (list.c:738)
==27863==    by 0x11A35B: list_node_create (list.c:665)
==27863==    by 0x112B2B: makeStmt (parse_tab.y:582)
==27863==    by 0x1130F7: makeDevice (parse_tab.y:685)
==27863==    by 0x114787: yyparse (parse_tab.y:176)
==27863==    by 0x114ABB: parse_config_file (parse_tab.y:368)
==27863==    by 0x114C43: conf_init (parse_util.c:90)
==27863==    by 0x10AE9F: main (powermand.c:124)
==27863== 
==27863== 1,280 bytes in 1 blocks are possibly lost in loss record 11 of 13
==27863==    at 0x4849E4C: malloc (vg_replace_malloc.c:307)
==27863==    by 0x11B2AF: list_alloc_aux (list.c:782)
==27863==    by 0x11B2AF: list_iterator_alloc (list.c:753)
==27863==    by 0x11B2AF: list_iterator_create (list.c:518)
==27863==    by 0x1152CF: pluglist_create (pluglist.c:81)
==27863==    by 0x1130B3: makeDevice (parse_tab.y:669)
==27863==    by 0x114787: yyparse (parse_tab.y:176)
==27863==    by 0x114ABB: parse_config_file (parse_tab.y:368)
==27863==    by 0x114C43: conf_init (parse_util.c:90)
==27863==    by 0x10AE9F: main (powermand.c:124)
==27863== 
==27863== 1,536 bytes in 3 blocks are possibly lost in loss record 12 of 13
==27863==    at 0x4849E4C: malloc (vg_replace_malloc.c:307)
==27863==    by 0x11A35B: list_alloc_aux (list.c:782)
==27863==    by 0x11A35B: list_node_alloc (list.c:738)
==27863==    by 0x11A35B: list_node_create (list.c:665)
==27863==    by 0x1119A3: yylex (parse_lex.l:85)
==27863==    by 0x113653: yyparse (parse_tab.c:1424)
==27863==    by 0x114ABB: parse_config_file (parse_tab.y:368)
==27863==    by 0x114C43: conf_init (parse_util.c:90)
==27863==    by 0x10AE9F: main (powermand.c:124)
==27863== 
==27863== LEAK SUMMARY:
==27863==    definitely lost: 0 bytes in 0 blocks
==27863==    indirectly lost: 0 bytes in 0 blocks
==27863==      possibly lost: 5,376 bytes in 9 blocks
==27863==    still reachable: 19,554 bytes in 6 blocks
==27863==         suppressed: 0 bytes in 0 blocks
==27863== Reachable blocks (those to which a pointer was found) are not shown.
==27863== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==27863== 
==27863== For lists of detected and suppressed errors, rerun with: -s
==27863== ERROR SUMMARY: 7 errors from 7 contexts (suppressed: 0 from 0)
```