### PR TITLE
testsuite: add clarification to sierra test script

### DIFF
--- a/t/t0026-llnl-sierra-cluster.t
+++ b/t/t0026-llnl-sierra-cluster.t
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-test_description='Check LLNL sierra cluster config with IPMI + PDU'
+test_description='Check LLNL sierra cluster config with IPMI + PDU
+
+This was a Dell cluster named sierra, circa 2010, not to be confused
+with the IBM cluster named sierra, sited in 2018.
+See also: chaos/powerman#115.
+'
 
 . `dirname $0`/sharness.sh
 


### PR DESCRIPTION
Problem: it is false advertising to have an llnl-sierra-cluster test script that has nothing to do with the record-setting IBM sierra system we that is around today.

Add a clarifying comment to the script.

Fixes #115