### PR TITLE
redfishpower: remove --hostsfile option

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -20,12 +20,6 @@ set simultaneously is limited by the file descriptor limit of the
 .B select(2)
 system call.
 .TP
-.I "-f, --hostsfile file"
-Alternate option to
-.I --hostname,
-specify a file with all hosts.  File shall have one host or hostrange
-listed per line.
-.TP
 .I "-H, --header string"
 Set extra HEADER to use.
 .TP

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -97,7 +97,6 @@ struct powermsg {
 #define OPTIONS "h:H:S:O:F:C:P:G:D:v"
 static struct option longopts[] = {
         {"hostname", required_argument, 0, 'h' },
-        {"hostsfile", required_argument, 0, 'f' },
         {"header", required_argument, 0, 'H' },
         {"statpath", required_argument, 0, 'S' },
         {"onpath", required_argument, 0, 'O' },
@@ -878,43 +877,6 @@ static void usage(void)
     exit(1);
 }
 
-/* copied from xread.c */
-static void _remove_trailing_whitespace(char *s)
-{
-    char *p = s + strlen(s) - 1;
-
-    while (p >= s && isspace(*p))
-        *p-- = '\0';
-}
-
-static void readhostsfile(const char *file)
-{
-    char buf[1024];
-    FILE *stream;
-
-    if (!hosts) {
-        if (!(hosts = hostlist_create(NULL)))
-            err_exit(true, "hostlist_create");
-    }
-
-    if (!(stream = fopen(file, "r")))
-        err_exit(true, "error opening file %s", file);
-
-    while (fgets(buf, 1024, stream)) {
-        _remove_trailing_whitespace(buf);
-        /* ignore empty lines */
-        if (strlen(buf) == 0)
-            continue;
-        /* ignore commented lines */
-        if (buf[0] == '#')
-            continue;
-        if (!hostlist_push(hosts, buf))
-            err_exit(true, "hostlist_push error on %s", optarg);
-    }
-
-    fclose(stream);
-}
-
 int main(int argc, char *argv[])
 {
     CURLM *mh;
@@ -934,9 +896,6 @@ int main(int argc, char *argv[])
                     if (!(hosts = hostlist_create(optarg)))
                         err_exit(true, "hostlist_create error on %s", optarg);
                 }
-                break;
-            case 'f': /* --hostsfile */
-                readhostsfile(optarg);
                 break;
             case 'H': /* --header */
                 header = xstrdup(optarg);


### PR DESCRIPTION
Problem: The redfishpower --hostsfile option is oddly included in the project as an option.  The suspicion is it was copy and paste from another project.  The short option for the option is not configured, but the long option is.  It is not documented in --help output, but is oddly documented in the manpage.

Drop the option.

----

I just saw this and was "uuhhhh why is this here"?