### PR TITLE
redfishpower: handle http 400 error

### DIFF
--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -846,7 +846,9 @@ static void shell(CURLM *mh)
                                                   CURLINFO_RESPONSE_CODE,
                                                   &code) != CURLE_OK)
                                 printf("%s: %s\n", pm->hostname, "http error");
-                            if (code == 401)
+                            if (code == 400)
+                                printf("%s: %s\n", pm->hostname, "bad request");
+                            else if (code == 401)
                                 printf("%s: %s\n", pm->hostname, "unauthorized");
                             else if (code == 404)
                                 printf("%s: %s\n", pm->hostname, "not found");


### PR DESCRIPTION
Problem: Some systems return an http 400 error when trying to power on an illegal subsystem.  Redfishpower currently does not handle this error code.

Add handling of error code 400, so we get a nice "bad request" error message.