### PR TITLE
enable valgrind test with suppressions

### DIFF
--- a/t/etc/valgrind.supp
+++ b/t/etc/valgrind.supp
@@ -1,0 +1,8 @@
+{
+   <liblsd_list_pool>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:list_alloc_aux
+   ...
+}

--- a/t/t0033-valgrind.t
+++ b/t/t0033-valgrind.t
@@ -8,6 +8,7 @@ powermand=$SHARNESS_BUILD_DIRECTORY/src/powerman/powermand
 powerman=$SHARNESS_BUILD_DIRECTORY/src/powerman/powerman
 vpcd=$SHARNESS_BUILD_DIRECTORY/t/simulators/vpcd
 vpcdev=$SHARNESS_TEST_SRCDIR/etc/vpc.dev
+suppressions=$SHARNESS_TEST_SRCDIR/etc/valgrind.supp
 
 # Use port = 11000 + test number
 # That way there won't be port conflicts with make -j
@@ -27,8 +28,9 @@ test_expect_success 'create test powerman.conf' '
 	alias "a0" "t0"
 	EOT
 '
-test_expect_failure 'run powermand --stdio under valgrind' '
+test_expect_success 'run powermand --stdio under valgrind' '
 	valgrind --tool=memcheck --leak-check=full --error-exitcode=1 \
+	    --gen-suppressions=all --suppressions=$suppressions \
 	    $powermand --stdio -c powerman.conf 2>valgrind.err <<-EOT
 	help
 	EOT


### PR DESCRIPTION
This enables the valgrind test added before, with suppressions for liblsd/list.

The issue where `powermand --stdio` would exit immediately when EOF was received on stdin is also fixed.  That was preventing any output from being sent, which is useful to see in test.