### PR TITLE
redfishpower: send http request after cmd active

### DIFF
--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -522,6 +522,9 @@ static void send_status_poll(zlistx_t *delayedcmds, struct powermsg *pm)
     /* issue a follow on stat to wait until the on/off is complete.
      * note that we set the initial start time of this new command to
      * the original on/off, so we can timeout correctly
+     *
+     * in addition, the cmd is the original on/off, indicating the true
+     * purpose of this status query
      */
     nextpm = powermsg_create(pm->mh,
                              pm->hostname,

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -965,9 +965,9 @@ static void shell(CURLM *mh)
                 else
                     power_cmd_process(delayedcmds, pm);
                 fflush(stdout);
-                zlistx_detach_cur(activecmds);
                 pm = zlistx_next(activecmds);
             }
+            zlistx_purge(activecmds);
         }
     }
     zlistx_destroy(&activecmds);


### PR DESCRIPTION
Problem: Whenever a power command message struct is created,  it is immediately initialized within curl, which means curl will immediately issue the http request once we enter the primary loop.  This isn't what is desired for "delayed cmds", i.e. status polling that we want to poll at a later time.
    
This happens to work right now because the only delayed commands we do is status polling.  If the current status polling happens to get the wrong answer, no biggie, we'll try again a second later when we issue the next status poll.  In the future, this will not be the case.  We will want delayed commands to issue their http requests at a later time.
    
Only initialize curl on a power command once it is added to the active list.

Added a cleanup commit on top.

Side note, I wasn't able to test on/off/cycle b/c I didn't have hardware available to try on, so only verified 'stat' worked.  But hopefully I didn't screw anything up royally :-)