### PR TITLE
redfish: always do off/delay/on for power cycle

### DIFF
--- a/etc/devices/redfishpower-cray-r272z30.dev
+++ b/etc/devices/redfishpower-cray-r272z30.dev
@@ -29,8 +29,6 @@ specification "redfishpower-cray-r272z30" {
 		expect "redfishpower> "
 		send "setoffpath redfish/v1/Systems/Self/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceOff\"}\n"
 		expect "redfishpower> "
-		send "setcyclepath redfish/v1/Systems/Self/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceRestart\"}\n"
-		expect "redfishpower> "
 		send "settimeout 60\n"
 		expect "redfishpower> "
 	}
@@ -54,7 +52,10 @@ specification "redfishpower-cray-r272z30" {
 		expect "redfishpower> "
 	}
 	script cycle_ranged {
-		send "cycle %s\n"
+		send "off %s\n"
+		expect "redfishpower> "
+		delay 2
+		send "on %s\n"
 		expect "redfishpower> "
 	}
 }

--- a/etc/devices/redfishpower-cray-windom.dev
+++ b/etc/devices/redfishpower-cray-windom.dev
@@ -62,6 +62,7 @@ specification "redfishpower-cray-windom-node0" {
 	script cycle_ranged {
 		send "off %s\n"
 		expect "redfishpower> "
+		delay 2
 		send "on %s\n"
 		expect "redfishpower> "
 	}
@@ -107,6 +108,7 @@ specification "redfishpower-cray-windom-node1" {
 	script cycle_ranged {
 		send "off %s\n"
 		expect "redfishpower> "
+		delay 2
 		send "on %s\n"
 		expect "redfishpower> "
 	}

--- a/etc/devices/redfishpower-supermicro.dev
+++ b/etc/devices/redfishpower-supermicro.dev
@@ -29,8 +29,6 @@ specification "redfishpower-supermicro" {
 		expect "redfishpower> "
 		send "setoffpath redfish/v1/Systems/1/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceOff\"}\n"
 		expect "redfishpower> "
-		send "setcyclepath redfish/v1/Systems/1/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceRestart\"}\n"
-		expect "redfishpower> "
 		send "settimeout 60\n"
 		expect "redfishpower> "
 	}
@@ -54,7 +52,10 @@ specification "redfishpower-supermicro" {
 		expect "redfishpower> "
 	}
 	script cycle_ranged {
-		send "cycle %s\n"
+		send "off %s\n"
+		expect "redfishpower> "
+		delay 2
+		send "on %s\n"
 		expect "redfishpower> "
 	}
 }

--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -109,23 +109,6 @@ Several paths the authors have seen include:
 .PP
 .B # curl -s -u USER:PASS -k -X GET https://<node>/redfish/v1/Systems/Self
 .LP
-To discover if \fIcycle\fR is supported, a path similar to the following might
-be found:
-.PP
-.B # curl -s -u USER:PASS -k -X GET https://<node>/redfish/v1/Systems/Node0/ResetActionInfo
-.LP
-If \fIcycle\fR (i.e. \fIForceRestart\fR) is not available, the
-\fIcycle_ranged\fR script could be replaced with.
-.PP
-.nf
-      script cycle_ranged {
-              send "off %s\\n"
-              expect "redfishpower> "
-              send "on %s\\n"
-              expect "redfishpower> "
-      }
-.fi
-.LP
 Internally within
 .B redfishpower,
 an \fIon\fR or \fIoff\fR command will not return until the
@@ -138,10 +121,10 @@ necessary, it should be increased at the top of the specification file
 (via \fItimeout\fR) and the login section of device file (via
 \fIsettimeout\fR).
 .LP
-Note that if \fIcycle_ranged\fR is scripted as an \fIoff\fR followed by an
-\fIon\fR, the
+Note that the
 .B powerman
-timeout should account for the combined time of both.
+timeout should account for the combined time of an \fIoff\fR and \fIon\fR
+for the \fIcycle\fR operation.
 
 .SH "FILES"
 @X_SBINDIR@/redfishpower

--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -32,17 +32,11 @@ Set Redfish path for performing power on.  Typically is redfish/v1/Systems/1/Act
 .I "-F, --offpath string"
 Set Redfish path for performing power off.  Typically is redfish/v1/Systems/1/Actions/ComputerSystem.Reset.
 .TP
-.I "-C, --cyclepath string"
-Set Redfish path for performing power cycle.  Typically is redfish/v1/Systems/1/Actions/ComputerSystem.Reset.
-.TP
 .I "-P, --onpostdata string"
 Set Redfish postdata for performing power on.  Typically is {"ResetType":"On"}
 .TP
 .I "-G, --offpostdata string"
 Set Redfish postdata for performing power off.  Typically is {"ResetType":"ForceOff"}
-.TP
-.I "-D, --cyclepostdata string"
-Set Redfish postdata for performing power cycle.  Typically is {"ResetType":"ForceRestart"}
 .TP
 .I "-v, --verbose"
 Increase output verbosity.
@@ -66,9 +60,6 @@ Set path and optional post data to turn on node.
 .I "setoffpath <path> [postdata]"
 Set path and optional post data to turn off node.
 .TP
-.I "setcyclepath <path> [postdata]"
-Set path and optional post data to cycle node.
-.TP
 .I "settimeout <seconds>"
 Set command timeout in seconds.
 .TP
@@ -80,9 +71,6 @@ Turn on all nodes or specified subset of nodes.  Will return "ok" after confirma
 .TP
 .I "off [nodes]"
 Turn off all nodes or specified subset of nodes.  Will return "ok" after confirmation "off" has completed.
-.TP
-.I "cycle [nodes]"
-Power cycle all nodes or specified subset of nodes.
 
 .SH "UPDATING REDFISHPOWER DEVICE FILES"
 .LP


### PR DESCRIPTION
Per discussion in #148

I think the first and second commit are pretty obvious given the discussion.

Commit number 3 is more debatable.  It would break backwards compatibility if anyone copied/modified an older redfishpower device file.

The primary reason I wanted to go down this path to remove redfishpower "cycle" is b/c parent support (#81) cannot work with native power cycle b/c of the inherent raciness of checking the power status after a power cycle.