### PR TITLE
WIP redfishpower: support cray supercomputing ex chassis & power control hierarchy

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -59,6 +59,7 @@ pkgsysconf_DATA = \
 	devices/redfishpower-cray-r272z30.dev \
 	devices/redfishpower-supermicro.dev \
 	devices/redfishpower-cray-windom.dev \
+	devices/redfishpower-hpe-cray-supercomputing-ex-chassis.dev \
 	devices/phantom.dev \
 	devices/plmpower.dev \
 	devices/powerman.dev \

--- a/etc/devices/redfishpower-hpe-cray-supercomputing-ex-chassis.dev
+++ b/etc/devices/redfishpower-hpe-cray-supercomputing-ex-chassis.dev
@@ -1,0 +1,302 @@
+# Support for Redfish Rest Interface
+#
+# How blades and switches in a HPE Cray Supercomputing EX Chassis
+# (abbreviated CrayEX) are populated has a large effect on
+# configuration.  Tweaks to this device file may be needed.  See the
+# section "UPDATING REDFISHPOWER DEVICE FILES" in redfishpower(8) for
+# additional tips.
+#
+# - Set your system's username/password in the login section of
+#   each specification below.
+#
+# General Configuration with "CrayEX" specification
+#
+# - assuming all blades populated with nodes, all switches populated.
+#   Take special notice to the order of hosts listed with `-h` as the
+#   order matters (plugnames are mapped to hosts via indices).  cmm
+#   should be listed first with the 16 nodes second.
+#
+#   include "/etc/powerman/redfishpower-hpe-cray-supercomputing-ex-chassis.dev"
+#   device "redfishpower" "CrayEX" "/usr/sbin/redfishpower -h -h cmm0,pmynode[0-15] |&"
+#   node "cmm0,myperif[0-7],myblade[0-7],mynode[0-15]" "redfishpower" "Enclosure,Perif[0-7],Blade[0-7],Node[0-15]"
+#
+# - If your chassis is not fully populated, put placeholder hosts in
+#   the redfishpower hosts configuration.  Adjust plugs when
+#   configuring specific targets.  For example, let's say perif[4-7]
+#   and blades[4-7] are not populated (thus nodes[8-15] also do not exist).
+#
+#   device "redfishpower" "redfishpower-CrayEX" "/usr/sbin/redfishpower -h cmm0,pnode[0-7],unused[0-7] |&"
+#   node "cmm0,myperif[0-3],myblade[0-3],mynode[0-7]" "redfishpower" "Enclosure,Perif[0-3],Blade[0-3],Node[0-7]"
+#
+# Rabbit Configuration with "CrayEX-rabbit-s4s7" specification
+#
+# - assuming all blades populated, switches 0-3 populated, rabbit in
+#   switch 4 & 7, rabbit drive in switch 4, rabbit blade in switch 7.
+#   Take special notice to the order of hosts listed with `-h` as the
+#   order matters (plugnames are mapped to hosts via indices).  cmm
+#   should be listed first, the 16 nodes second, and the rabbit last.
+#   Take note that the plugname "Node16" is used for the rabbit.
+#
+#   include "/etc/powerman/redfishpower-hpe-cray-supercomputing-ex-chassis.dev"
+#   device "redfishpower" "CrayEX-rabbit-s4s7" "/usr/sbin/redfishpower -h -h cmm0,pmynode[0-15],pmyrabbit0 |&"
+#   node "cmm0,myperif[0-4,7],myblade[0-7],mynode[0-15],myrabbit0" "redfishpower" "Enclosure,Perif[0-4,7],Blade[0-7],Node[0-16]"
+#
+# - If your chassis is not fully populated, again put placeholder
+#   hosts in the redfishpower hosts configuration and adjust plugs
+#   when configuring specific targets.  Let's say blades[4-7] (and
+#   thus nodes[8-15]) are not populated.
+#
+#   device "redfishpower" "redfishpower-CrayEX-rabbit-s4s7" "/usr/sbin/redfishpower -h cmm0,pmynode[0-7],unused[0-7],pmyrabbit0 |&"
+#   node "cmm0,myperif[0-4,7],myblade[0-3],mynode[0-7],myrabbit0" "redfishpower" "Enclosure,Perif[0-4,7],Blade[0-3],Node[0-7,16]"
+#
+specification "redfishpower-CrayEX" {
+	timeout 	100
+
+	plug name {
+		"Enclosure"
+		"Perif0"
+		"Perif1"
+		"Perif2"
+		"Perif3"
+		"Perif4"
+		"Perif5"
+		"Perif6"
+		"Perif7"
+		"Blade0"
+		"Blade1"
+		"Blade2"
+		"Blade3"
+		"Blade4"
+		"Blade5"
+		"Blade6"
+		"Blade7"
+		"Node0"
+		"Node1"
+		"Node2"
+		"Node3"
+		"Node4"
+		"Node5"
+		"Node6"
+		"Node7"
+		"Node8"
+		"Node9"
+		"Node10"
+		"Node11"
+		"Node12"
+		"Node13"
+		"Node14"
+		"Node15"
+	}
+
+	script login {
+		expect "redfishpower> "
+		send "auth USER:PASS\n"
+		expect "redfishpower> "
+		send "setheader Content-Type:application/json\n"
+		expect "redfishpower> "
+		send "setplugs Enclosure 0\n"
+		expect "redfishpower> "
+		send "setplugs Perif[0-7],Blade[0-7] 0 Enclosure\n"
+		expect "redfishpower> "
+		send "setplugs Node[0-1] [1-2] Blade0\n"
+		expect "redfishpower> "
+		send "setplugs Node[2-3] [3-4] Blade1\n"
+		expect "redfishpower> "
+		send "setplugs Node[4-5] [5-6] Blade2\n"
+		expect "redfishpower> "
+		send "setplugs Node[6-7] [7-8] Blade3\n"
+		expect "redfishpower> "
+		send "setplugs Node[8-9] [9-10] Blade4\n"
+		expect "redfishpower> "
+		send "setplugs Node[10-11] [11-12] Blade5\n"
+		expect "redfishpower> "
+		send "setplugs Node[12-13] [13-14] Blade6\n"
+		expect "redfishpower> "
+		send "setplugs Node[14-15] [15-16] Blade7\n"
+		expect "redfishpower> "
+		send "setpath Enclosure,Perif[0-7],Blade[0-7] stat redfish/v1/Chassis/{{plug}}\n"
+		expect "redfishpower> "
+		send "setpath Enclosure,Perif[0-7],Blade[0-7] on redfish/v1/Chassis/{{plug}}/Actions/Chassis.Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setpath Enclosure,Perif[0-7],Blade[0-7] off redfish/v1/Chassis/{{plug}}/Actions/Chassis.Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-15] stat redfish/v1/Systems/Node0\n"
+		expect "redfishpower> "
+		send "setpath Node[0-15] on redfish/v1/Systems/Node0/Actions/ComputerSystem.Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-15] off redfish/v1/Systems/Node0/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "settimeout 75\n"
+		expect "redfishpower> "
+	}
+	script logout {
+		send "quit\n"
+	}
+	# status script used if not targeting all plugs
+	# - needed if chassis is not fully populated
+	script status {
+		send "stat %s\n"
+		expect "([^\n:]+): ([^\n]+\n)"
+		setplugstate $1 $2 on="^on\n" off="^off\n"
+		expect "redfishpower> "
+	}
+	script status_all {
+		send "stat\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setplugstate $1 $2 on="^on\n" off="^off\n"
+		}
+		expect "redfishpower> "
+	}
+	script on_ranged {
+		send "on %s\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setresult $1 $2 success="^ok\n"
+		}
+		expect "redfishpower> "
+	}
+	script off_ranged {
+		send "off %s\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setresult $1 $2 success="^ok\n"
+		}
+		expect "redfishpower> "
+	}
+	script cycle_ranged {
+		send "off %s\n"
+		expect "redfishpower> "
+		delay 2
+		send "on %s\n"
+		expect "redfishpower> "
+	}
+}
+
+# Rabbit takes up 4 switch slots but is powered by 4 & 7.  4 powers
+# the drives, 7 powers the node, thus 7 parent of rabbit.
+
+specification "redfishpower-CrayEX-rabbit-s4s7" {
+	timeout 	100
+
+	plug name {
+		"Enclosure"
+		"Perif0"
+		"Perif1"
+		"Perif2"
+		"Perif3"
+		"Perif4"
+		"Perif7"
+		"Blade0"
+		"Blade1"
+		"Blade2"
+		"Blade3"
+		"Blade4"
+		"Blade5"
+		"Blade6"
+		"Blade7"
+		"Node0"
+		"Node1"
+		"Node2"
+		"Node3"
+		"Node4"
+		"Node5"
+		"Node6"
+		"Node7"
+		"Node8"
+		"Node9"
+		"Node10"
+		"Node11"
+		"Node12"
+		"Node13"
+		"Node14"
+		"Node15"
+		"Node16"
+	}
+
+	script login {
+		expect "redfishpower> "
+		send "auth USER:PASS\n"
+		expect "redfishpower> "
+		send "setheader Content-Type:application/json\n"
+		expect "redfishpower> "
+		send "setplugs Enclosure 0\n"
+		expect "redfishpower> "
+		send "setplugs Perif[0-4,7],Blade[0-7] 0 Enclosure\n"
+		expect "redfishpower> "
+		send "setplugs Node[0-1] [1-2] Blade0\n"
+		expect "redfishpower> "
+		send "setplugs Node[2-3] [3-4] Blade1\n"
+		expect "redfishpower> "
+		send "setplugs Node[4-5] [5-6] Blade2\n"
+		expect "redfishpower> "
+		send "setplugs Node[6-7] [7-8] Blade3\n"
+		expect "redfishpower> "
+		send "setplugs Node[8-9] [9-10] Blade4\n"
+		expect "redfishpower> "
+		send "setplugs Node[10-11] [11-12] Blade5\n"
+		expect "redfishpower> "
+		send "setplugs Node[12-13] [13-14] Blade6\n"
+		expect "redfishpower> "
+		send "setplugs Node[14-15] [15-16] Blade7\n"
+		expect "redfishpower> "
+		send "setplugs Node16 17 Perif7\n"
+		expect "redfishpower> "
+		send "setpath Enclosure,Perif[0-4,7],Blade[0-7] stat redfish/v1/Chassis/{{plug}}\n"
+		expect "redfishpower> "
+		send "setpath Enclosure,Perif[0-4,7],Blade[0-7] on redfish/v1/Chassis/{{plug}}/Actions/Chassis.Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setpath Enclosure,Perif[0-4,7],Blade[0-7] off redfish/v1/Chassis/{{plug}}/Actions/Chassis.Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-16] stat redfish/v1/Systems/Node0\n"
+		expect "redfishpower> "
+		send "setpath Node[0-16] on redfish/v1/Systems/Node0/Actions/ComputerSystem.Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-16] off redfish/v1/Systems/Node0/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "settimeout 75\n"
+		expect "redfishpower> "
+	}
+	script logout {
+		send "quit\n"
+	}
+	# status script used if not targeting all plugs
+	# - needed if chassis is not fully populated
+	script status {
+		send "stat %s\n"
+		expect "([^\n:]+): ([^\n]+\n)"
+		setplugstate $1 $2 on="^on\n" off="^off\n"
+		expect "redfishpower> "
+	}
+	script status_all {
+		send "stat\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setplugstate $1 $2 on="^on\n" off="^off\n"
+		}
+		expect "redfishpower> "
+	}
+	script on_ranged {
+		send "on %s\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setresult $1 $2 success="^ok\n"
+		}
+		expect "redfishpower> "
+	}
+	script off_ranged {
+		send "off %s\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setresult $1 $2 success="^ok\n"
+		}
+		expect "redfishpower> "
+	}
+	script cycle_ranged {
+		send "off %s\n"
+		expect "redfishpower> "
+		delay 2
+		send "on %s\n"
+		expect "redfishpower> "
+	}
+}

--- a/man/powerman.1.in
+++ b/man/powerman.1.in
@@ -85,6 +85,10 @@ Retry connect to server up to N times with a 100ms delay after each failure.
 .I "-d, --device"
 Displays device status information for the device(s) that control the targets,
 if specified, or all devices if not.
+.Tp
+.I "-D, --diag"
+Display diagnostic errors for power control/query failures.  Support dependent
+on device support and not available on many devices.
 .SH "TARGET SPECIFICATION"
 .B powerman
 target hostnames may be specified as comma separated or space separated

--- a/src/powerman/Makefile.am
+++ b/src/powerman/Makefile.am
@@ -2,6 +2,7 @@ AM_CFLAGS = @WARNING_CFLAGS@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/liblsd \
+	-I$(top_srcdir)/src/libczmq \
 	-I$(top_srcdir)/src/libcommon
 
 bin_PROGRAMS = \
@@ -59,6 +60,7 @@ powermand_SOURCES = \
 
 powermand_LDADD = \
 	$(top_builddir)/src/liblsd/liblsd.la \
+	$(top_builddir)/src/libczmq/libczmq.la \
 	$(top_builddir)/src/libcommon/libcommon.la \
 	$(LIBWRAP)
 

--- a/src/powerman/client_proto.h
+++ b/src/powerman/client_proto.h
@@ -48,6 +48,7 @@
 #define CP_BEACON_OFF "unflash %s"
 #define CP_TELEMETRY  "telemetry"
 #define CP_EXPRANGE   "exprange"
+#define CP_DIAG       "diag"
 
 /*
  * Responses -
@@ -67,6 +68,7 @@
 #define CP_RSP_QRY_COMPLETE "103 Query complete"                    CP_EOL
 #define CP_RSP_TELEMETRY    "104 Telemetry %s"                      CP_EOL
 #define CP_RSP_EXPRANGE     "105 Hostrange expansion %s"            CP_EOL
+#define CP_RSP_DIAG         "106 Diag %s"                           CP_EOL
 
 /* failure 2xx */
 #define CP_ERR_UNKNOWN      "201 Unknown command"                   CP_EOL
@@ -108,6 +110,7 @@
 #define CP_INFO_NODES       "306 %s"                                CP_EOL
 #define CP_INFO_XNODES      "307 %s"                                CP_EOL
 #define CP_INFO_ACTERROR    "308 %s"                                CP_EOL
+#define CP_INFO_DIAG        "309 %s: %s"                            CP_EOL
 
 #endif  /* PM_CLIENT_PROTO_H */
 

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -75,7 +75,8 @@ static zhashx_t *test_power_status;
 /* in usec
  *
  * status polling interval of 1 second may seem long, but testing
- * shows wait ranges from a few seconds to 20 seconds
+ * shows wait for on/off to complete ranges from a few seconds to 50
+ * seconds
  */
 #define STATUS_POLLING_INTERVAL_DEFAULT  1000000
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -43,7 +43,8 @@ TESTSCRIPTS = \
 	t0032-list.t \
 	t0033-valgrind.t \
 	t0034-redfishpower.t \
-	t0035-power-result.t
+	t0035-power-result.t \
+	t0036-diag.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/t0029-redfish.t
+++ b/t/t0029-redfish.t
@@ -107,6 +107,378 @@ test_expect_success 'stop powerman daemon' '
 	wait
 '
 
+#
+# redfishpower hpe cray supercomputing ex chassis test
+#
+
+test_expect_success 'create powerman.conf for chassis w/ 16 redfish nodes (crayex)' '
+	cat >powerman_hpe_cray_supercomputing_ex_chassis.conf <<-EOT
+	listen "$testaddr"
+	include "$devicesdir/redfishpower-hpe-cray-supercomputing-ex-chassis.dev"
+	device "d0" "redfishpower-CrayEX" "$redfishdir/redfishpower -h cmm0,t[0-15] --test-mode |&"
+	node "cmm0,perif[0-7],blade[0-7],t[0-15]" "d0"
+	EOT
+'
+test_expect_success 'start powerman daemon and wait for it to start (crayex)' '
+	$powermand -Y -c powerman_hpe_cray_supercomputing_ex_chassis.conf &
+	echo $! >powermand.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -d
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayex_query1.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-7],t[0-15]" "" >test_crayex_query1.exp &&
+	test_cmp test_crayex_query1.exp test_crayex_query1.out
+'
+# powering on descendants with cmm off, nothing turns on
+test_expect_success 'powerman -1 blade[0-7] doesnt work' '
+	test_must_fail $powerman -h $testaddr --diag -1 blade[0-7] >test_crayex_on1.out &&
+	echo blade[0-7]: ancestor off >test_crayex_on1.exp &&
+	echo Command completed with errors >>test_crayex_on1.exp &&
+	test_cmp test_crayex_on1.exp test_crayex_on1.out
+'
+test_expect_success 'powerman -1 perif[0-7] doesnt work' '
+	test_must_fail $powerman -h $testaddr --diag -1 perif[0-7] >test_crayex_on2.out &&
+	echo perif[0-7]: ancestor off >test_crayex_on2.exp &&
+	echo Command completed with errors >>test_crayex_on2.exp &&
+	test_cmp test_crayex_on2.exp test_crayex_on2.out
+'
+test_expect_success 'powerman -1 t[0-15] doesnt work' '
+	test_must_fail $powerman -h $testaddr --diag -1 t[0-15] >test_crayex_on3.out &&
+	echo t[0-15]: ancestor off >test_crayex_on3.exp &&
+	echo Command completed with errors >>test_crayex_on3.exp &&
+	test_cmp test_crayex_on3.exp test_crayex_on3.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayex_query2.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-7],t[0-15]" "" >test_crayex_query2.exp &&
+	test_cmp test_crayex_query2.exp test_crayex_query2.out
+'
+# turn on cmm works
+test_expect_success 'powerman -1 cmm0 completes' '
+	$powerman -h $testaddr -1 cmm0 >test_crayex_on4.out &&
+	echo Command completed successfully >test_crayex_on4.exp &&
+	test_cmp test_crayex_on4.exp test_crayex_on4.out
+'
+test_expect_success 'powerman -q shows cmm0 on' '
+	$powerman -h $testaddr -q >test_crayex_query3.out &&
+	makeoutput "cmm0" "blade[0-7],perif[0-7],t[0-15]" "" >test_crayex_query3.exp &&
+	test_cmp test_crayex_query3.exp test_crayex_query3.out
+'
+# turn on children of blades does not work
+test_expect_success 'powerman -1 t[0-15] doesnt work' '
+	test_must_fail $powerman -h $testaddr --diag -1 t[0-15] >test_crayex_on5.out &&
+	echo t[0-15]: ancestor off >test_crayex_on5.exp &&
+	echo Command completed with errors >>test_crayex_on5.exp &&
+	test_cmp test_crayex_on5.exp test_crayex_on5.out
+'
+test_expect_success 'powerman -q shows cmm0 on' '
+	$powerman -h $testaddr -q >test_crayex_query4.out &&
+	makeoutput "cmm0" "blade[0-7],perif[0-7],t[0-15]" "" >test_crayex_query4.exp &&
+	test_cmp test_crayex_query4.exp test_crayex_query4.out
+'
+# turn on some blades, allows some nodes to be turned on
+test_expect_success 'powerman -1 blade[4-7] completes' '
+	$powerman -h $testaddr -1 blade[4-7] >test_crayex_on6.out &&
+	echo Command completed successfully >test_crayex_on6.exp &&
+	test_cmp test_crayex_on6.exp test_crayex_on6.out
+'
+test_expect_success 'powerman -1 t[0-15] doesnt work, some succeed' '
+	test_must_fail $powerman -h $testaddr --diag -1 t[0-15] >test_crayex_on7.out &&
+	echo t[0-7]: ancestor off >test_crayex_on7.exp &&
+	echo Command completed with errors >>test_crayex_on7.exp &&
+	test_cmp test_crayex_on7.exp test_crayex_on7.out
+'
+test_expect_success 'powerman -q shows blade[4-7],cmm0,t[8-15] on' '
+	$powerman -h $testaddr -q >test_crayex_query5.out &&
+	makeoutput "blade[4-7],cmm0,t[8-15]" "blade[0-3],perif[0-7],t[0-7]" "" >test_crayex_query5.exp &&
+	test_cmp test_crayex_query5.exp test_crayex_query5.out
+'
+# turn on blades and perif and then nodes
+test_expect_success 'powerman -1 blade[0-3],perif[0-7] completes' '
+	$powerman -h $testaddr -1 blade[0-3],perif[0-7] >test_crayex_on8.out &&
+	echo Command completed successfully >test_crayex_on8.exp &&
+	test_cmp test_crayex_on8.exp test_crayex_on8.out
+'
+test_expect_success 'powerman -q shows blade[0-7],cmm0,perif[0-7] on' '
+	$powerman -h $testaddr -q >test_crayex_query6.out &&
+	makeoutput "blade[0-7],cmm0,perif[0-7],t[8-15]" "t[0-7]" "" >test_crayex_query6.exp &&
+	test_cmp test_crayex_query6.exp test_crayex_query6.out
+'
+test_expect_success 'powerman -1 t[0-15] completes' '
+	$powerman -h $testaddr -1 t[0-15] >test_crayex_on6.out &&
+	echo Command completed successfully >test_crayex_on6.exp &&
+	test_cmp test_crayex_on6.exp test_crayex_on6.out
+'
+test_expect_success 'powerman -q shows blade[0-7],cmm0,t[0-15] on' '
+	$powerman -h $testaddr -q >test_crayex_query7.out &&
+	makeoutput "blade[0-7],cmm0,perif[0-7],t[0-15]" "" "" >test_crayex_query7.exp &&
+	test_cmp test_crayex_query7.exp test_crayex_query7.out
+'
+# turn off leaves works
+test_expect_success 'powerman -0 t[8-15] completes' '
+	$powerman -h $testaddr -0 t[8-15] >test_crayex_off1.out &&
+	echo Command completed successfully >test_crayex_off1.exp &&
+	test_cmp test_crayex_off1.exp test_crayex_off1.out
+'
+test_expect_success 'powerman -q shows blade[0-7],cmm0,t[0-7] on' '
+	$powerman -h $testaddr -q >test_crayex_query8.out &&
+	makeoutput "blade[0-7],cmm0,perif[0-7],t[0-7]" "t[8-15]" "" >test_crayex_query8.exp &&
+	test_cmp test_crayex_query8.exp test_crayex_query8.out
+'
+# turn off level 2 perif & blades, remaining leaves are now off
+test_expect_success 'powerman -0 blade[0-7],perif[0-7] completes' '
+	$powerman -h $testaddr -0 blade[0-7],perif[0-7] >test_crayex_off2.out &&
+	echo Command completed successfully >test_crayex_off2.exp &&
+	test_cmp test_crayex_off2.exp test_crayex_off2.out
+'
+test_expect_success 'powerman -q shows cmm0 on' '
+	$powerman -h $testaddr -q >test_crayex_query9.out &&
+	makeoutput "cmm0" "blade[0-7],perif[0-7],t[0-15]" "" >test_crayex_query9.exp &&
+	test_cmp test_crayex_query9.exp test_crayex_query9.out
+'
+# turn off cmm works
+test_expect_success 'powerman -0 cmm0 completes' '
+	$powerman -h $testaddr -0 cmm0 >test_crayex_off3.out &&
+	echo Command completed successfully >test_crayex_off3.exp &&
+	test_cmp test_crayex_off3.exp test_crayex_off3.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayex_query10.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-7],t[0-15]" "" >test_crayex_query10.exp &&
+	test_cmp test_crayex_query10.exp test_crayex_query10.out
+'
+# turn on everything doesn't work
+test_expect_success 'powerman -1 blade[0-7],cmm0,perif[0-7],t[0-15] doesnt work' '
+	test_must_fail $powerman -h $testaddr --diag -1 blade[0-7],cmm0,perif[0-7],t[0-15] >test_crayex_on9.out &&
+	echo blade[0-7],cmm0,perif[0-7],t[0-15]: cannot turn on parent and child >test_crayex_on9.exp &&
+	echo Command completed with errors >>test_crayex_on9.exp &&
+	test_cmp test_crayex_on9.exp test_crayex_on9.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayex_query11.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-7],t[0-15]" "" >test_crayex_query11.exp &&
+	test_cmp test_crayex_query11.exp test_crayex_query11.out
+'
+# turn everything on
+test_expect_success 'powerman turn on everything' '
+	$powerman -h $testaddr -1 cmm0 >test_crayex_on9A.out &&
+	echo Command completed successfully >test_crayex_on9A.exp &&
+	test_cmp test_crayex_on9A.exp test_crayex_on9A.out &&
+	$powerman -h $testaddr -1 blade[0-7],perif[0-7] >test_crayex_on9B.out &&
+	echo Command completed successfully >test_crayex_on9B.exp &&
+	test_cmp test_crayex_on9B.exp test_crayex_on9B.out &&
+	$powerman -h $testaddr -1 t[0-15] >test_crayex_on9C.out &&
+	echo Command completed successfully >test_crayex_on9C.exp &&
+	test_cmp test_crayex_on9C.exp test_crayex_on9C.out
+'
+test_expect_success 'powerman -q shows all on' '
+	$powerman -h $testaddr -q >test_crayex_query12.out &&
+	makeoutput "blade[0-7],cmm0,perif[0-7],t[0-15]" "" "" >test_crayex_query12.exp &&
+	test_cmp test_crayex_query12.exp test_crayex_query12.out
+'
+# turn off everything works
+test_expect_success 'powerman -0 blade[0-3],cmm0,perif[0-7],t[0-15] completes' '
+	$powerman -h $testaddr -0 blade[0-3],cmm0,perif[0-7],t[0-15] >test_crayex_off4.out &&
+	echo Command completed successfully >test_crayex_off4.exp &&
+	test_cmp test_crayex_off4.exp test_crayex_off4.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayex_query13.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-7],t[0-15]" "" >test_crayex_query13.exp &&
+	test_cmp test_crayex_query13.exp test_crayex_query13.out
+'
+test_expect_success 'stop powerman daemon (crayex)' '
+	kill -15 $(cat powermand.pid) &&
+	wait
+'
+
+#
+# redfishpower hpe cray supercomputing ex chassis test - some unpopulated
+#
+# assume perif[4-7] and blade[4-7] do not exist
+# as a result t[8-15] do not exist
+#
+
+test_expect_success 'create powerman.conf for chassis w/ 16 redfish nodes (crayexU)' '
+	cat >powerman_hpe_cray_supercomputing_ex_chassis_U.conf <<-EOT
+	listen "$testaddr"
+	include "$devicesdir/redfishpower-hpe-cray-supercomputing-ex-chassis.dev"
+	device "d0" "redfishpower-CrayEX" "$redfishdir/redfishpower -h cmm0,t[0-7],unused[0-7] --test-mode |&"
+	node "cmm0,perif[0-3],blade[0-3],t[0-7]" "d0" "Enclosure,Perif[0-3],Blade[0-3],Node[0-7]"
+	EOT
+'
+test_expect_success 'start powerman daemon and wait for it to start (crayexU)' '
+	$powermand -Y -c powerman_hpe_cray_supercomputing_ex_chassis_U.conf &
+	echo $! >powermand.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -d
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayexU_query1.out &&
+	makeoutput "" "blade[0-3],cmm0,perif[0-3],t[0-7]" "" >test_crayexU_query1.exp &&
+	test_cmp test_crayexU_query1.exp test_crayexU_query1.out
+'
+# turn on undefined stuff leads to errors
+test_expect_success 'powerman fails on unpopulated targets' '
+	test_must_fail $powerman -h $testaddr -1 blade4 &&
+	test_must_fail $powerman -h $testaddr -1 perif5 &&
+	test_must_fail $powerman -h $testaddr -1 t8
+'
+# turn on everything works
+test_expect_success 'powerman turn on everything' '
+	$powerman -h $testaddr -1 cmm0 >test_crayexU_on9A.out &&
+	echo Command completed successfully >test_crayexU_on9A.exp &&
+	test_cmp test_crayexU_on9A.exp test_crayexU_on9A.out &&
+	$powerman -h $testaddr -1 blade[0-3],perif[0-3] >test_crayexU_on9B.out &&
+	echo Command completed successfully >test_crayexU_on9B.exp &&
+	test_cmp test_crayexU_on9B.exp test_crayexU_on9B.out &&
+	$powerman -h $testaddr -1 t[0-7] >test_crayexU_on9C.out &&
+	echo Command completed successfully >test_crayexU_on9C.exp &&
+	test_cmp test_crayexU_on9C.exp test_crayexU_on9C.out
+'
+test_expect_success 'powerman -q shows all on' '
+	$powerman -h $testaddr -q >test_crayexU_query2.out &&
+	makeoutput "blade[0-3],cmm0,perif[0-3],t[0-7]" "" "" >test_crayexU_query2.exp &&
+	test_cmp test_crayexU_query2.exp test_crayexU_query2.out
+'
+# turn off everything works
+test_expect_success 'powerman -0 blade[0-3],cmm0,perif[0-3],t[0-7] completes' '
+	$powerman -h $testaddr -0 blade[0-3],cmm0,perif[0-3],t[0-7] >test_crayexU_off1.out &&
+	echo Command completed successfully >test_crayexU_off1.exp &&
+	test_cmp test_crayexU_off1.exp test_crayexU_off1.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayexU_query3.out &&
+	makeoutput "" "blade[0-3],cmm0,perif[0-3],t[0-7]" "" >test_crayexU_query3.exp &&
+	test_cmp test_crayexU_query3.exp test_crayexU_query3.out
+'
+test_expect_success 'stop powerman daemon (crayexU)' '
+	kill -15 $(cat powermand.pid) &&
+	wait
+'
+
+#
+# redfishpower hpe cray supercomputing ex chassis test - rabbit
+#
+# rabbit is descendant of perif 7
+#
+
+test_expect_success 'create powerman.conf for chassis w/ 16 redfish nodes (crayexR)' '
+	cat >powerman_hpe_cray_supercomputing_ex_chassis_U.conf <<-EOT
+	listen "$testaddr"
+	include "$devicesdir/redfishpower-hpe-cray-supercomputing-ex-chassis.dev"
+	device "d0" "redfishpower-CrayEX-rabbit-s4s7" "$redfishdir/redfishpower -h cmm0,t[0-15],rabbit --test-mode |&"
+	node "cmm0,perif[0-4,7],blade[0-7],t[0-15],rabbit" "d0" "Enclosure,Perif[0-4,7],Blade[0-7],Node[0-16]"
+	EOT
+'
+test_expect_success 'start powerman daemon and wait for it to start (crayexR)' '
+	$powermand -Y -c powerman_hpe_cray_supercomputing_ex_chassis_U.conf &
+	echo $! >powermand.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -d
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayexR_query1.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-4,7],rabbit,t[0-15]" "" >test_crayexR_query1.exp &&
+	test_cmp test_crayexR_query1.exp test_crayexR_query1.out
+'
+# powering on rabbit with cmm and perif7 off
+test_expect_success 'powerman -1 rabbit doesnt work' '
+	test_must_fail $powerman -h $testaddr --diag -1 rabbit >test_crayexR_on1.out &&
+	echo rabbit: ancestor off >test_crayexR_on1.exp &&
+	echo Command completed with errors >>test_crayexR_on1.exp &&
+	test_cmp test_crayexR_on1.exp test_crayexR_on1.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayexR_query2.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-4,7],rabbit,t[0-15]" "" >test_crayexR_query2.exp &&
+	test_cmp test_crayexR_query2.exp test_crayexR_query2.out
+'
+# turn on cmm works, can't turn on rabbit
+test_expect_success 'powerman -1 cmm0 completes' '
+	$powerman -h $testaddr -1 cmm0 >test_crayexR_on2.out &&
+	echo Command completed successfully >test_crayexR_on2.exp &&
+	test_cmp test_crayexR_on2.exp test_crayexR_on2.out
+'
+test_expect_success 'powerman -1 rabbit doesnt work' '
+	test_must_fail $powerman -h $testaddr --diag -1 rabbit >test_crayexR_on3.out &&
+	echo rabbit: ancestor off >test_crayexR_on3.exp &&
+	echo Command completed with errors >>test_crayexR_on3.exp &&
+	test_cmp test_crayexR_on3.exp test_crayexR_on3.out
+'
+test_expect_success 'powerman -q shows cmm0 on' '
+	$powerman -h $testaddr -q >test_crayexR_query3.out &&
+	makeoutput "cmm0" "blade[0-7],perif[0-4,7],rabbit,t[0-15]" "" >test_crayexR_query3.exp &&
+	test_cmp test_crayexR_query3.exp test_crayexR_query3.out
+'
+# turn on perif7 works, can turn on rabbit now
+test_expect_success 'powerman -1 perif7 completes' '
+	$powerman -h $testaddr -1 perif7 >test_crayexR_on4.out &&
+	echo Command completed successfully >test_crayexR_on4.exp &&
+	test_cmp test_crayexR_on4.exp test_crayexR_on4.out
+'
+test_expect_success 'powerman -1 rabbit completes' '
+	$powerman -h $testaddr -1 rabbit >test_crayexR_on5.out &&
+	echo Command completed successfully >test_crayexR_on5.exp &&
+	test_cmp test_crayexR_on5.exp test_crayexR_on5.out
+'
+test_expect_success 'powerman -q shows cmm0,perif7,rabbit on' '
+	$powerman -h $testaddr -q >test_crayexR_query4.out &&
+	makeoutput "cmm0,perif7,rabbit" "blade[0-7],perif[0-4],t[0-15]" "" >test_crayexR_query4.exp &&
+	test_cmp test_crayexR_query4.exp test_crayexR_query4.out
+'
+# turn off rabbit, perif7, cmm0
+test_expect_success 'powerman -0 rabbit completes' '
+	$powerman -h $testaddr -0 rabbit >test_crayexR_off1.out &&
+	echo Command completed successfully >test_crayexR_off1.exp &&
+	test_cmp test_crayexR_off1.exp test_crayexR_off1.out
+'
+test_expect_success 'powerman -0 perif7 completes' '
+	$powerman -h $testaddr -0 perif7 >test_crayexR_off2.out &&
+	echo Command completed successfully >test_crayexR_off2.exp &&
+	test_cmp test_crayexR_off2.exp test_crayexR_off2.out
+'
+test_expect_success 'powerman -0 cmm0 completes' '
+	$powerman -h $testaddr -0 cmm0 >test_crayexR_off3.out &&
+	echo Command completed successfully >test_crayexR_off3.exp &&
+	test_cmp test_crayexR_off3.exp test_crayexR_off3.out
+'
+test_expect_success 'powerman -q shows everything off' '
+	$powerman -h $testaddr -q >test_crayexR_query5.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-4,7],rabbit,t[0-15]" "" >test_crayexR_query5.exp &&
+	test_cmp test_crayexR_query5.exp test_crayexR_query5.out
+'
+# turn on everything
+test_expect_success 'powerman turn on everything' '
+	$powerman -h $testaddr -1 cmm0 >test_crayexR_on6A.out &&
+	echo Command completed successfully >test_crayexR_on6A.exp &&
+	test_cmp test_crayexR_on6A.exp test_crayexR_on6A.out &&
+	$powerman -h $testaddr -1 blade[0-7],perif[0-4,7] >test_crayexR_on6B.out &&
+	echo Command completed successfully >test_crayexR_on6B.exp &&
+	test_cmp test_crayexR_on6B.exp test_crayexR_on6B.out &&
+	$powerman -h $testaddr -1 t[0-15],rabbit >test_crayexR_on6C.out &&
+	echo Command completed successfully >test_crayexR_on6C.exp &&
+	test_cmp test_crayexR_on6C.exp test_crayexR_on6C.out
+'
+test_expect_success 'powerman -q shows all on' '
+	$powerman -h $testaddr -q >test_crayexR_query6.out &&
+	makeoutput "blade[0-7],cmm0,perif[0-4,7],rabbit,t[0-15]" "" "" >test_crayexR_query6.exp &&
+	test_cmp test_crayexR_query6.exp test_crayexR_query6.out
+'
+# turn off everything works
+test_expect_success 'powerman -0 blade[0-7],cmm0,perif[0-4,7],rabbit,t[0-15] completes' '
+	$powerman -h $testaddr -0 blade[0-7],cmm0,perif[0-4,7],rabbit,t[0-15] >test_crayexR_off4.out &&
+	echo Command completed successfully >test_crayexR_off4.exp &&
+	test_cmp test_crayexR_off4.exp test_crayexR_off4.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr -q >test_crayexR_query7.out &&
+	makeoutput "" "blade[0-7],cmm0,perif[0-4,7],rabbit,t[0-15]" "" >test_crayexR_query7.exp &&
+	test_cmp test_crayexR_query7.exp test_crayexR_query7.out
+'
+test_expect_success 'stop powerman daemon (crayexR)' '
+	kill -15 $(cat powermand.pid) &&
+	wait
+'
+
 test_done
 
 # vi: set ft=sh

--- a/t/t0036-diag.t
+++ b/t/t0036-diag.t
@@ -1,0 +1,163 @@
+#!/bin/sh
+
+test_description='Test Powerman diag'
+
+. `dirname $0`/sharness.sh
+
+powermand=$SHARNESS_BUILD_DIRECTORY/src/powerman/powermand
+powerman=$SHARNESS_BUILD_DIRECTORY/src/powerman/powerman
+vpcd=$SHARNESS_BUILD_DIRECTORY/t/simulators/vpcd
+vpcdev=$SHARNESS_TEST_SRCDIR/etc/vpc.dev
+
+# Use port = 11000 + test number
+# That way there won't be port conflicts with make -j
+testaddr=localhost:11036
+
+makeoutput() {
+	printf "on:      %s\n" $1
+	printf "off:     %s\n" $2
+	printf "unknown: %s\n" $3
+}
+
+test_expect_success 'create test powerman.conf' '
+	cat >powerman.conf <<-EOT
+	include "$vpcdev"
+	listen "$testaddr"
+	device "test0" "vpc" "$vpcd |&"
+	node "t[0-15]" "test0"
+	EOT
+'
+test_expect_success 'start powerman daemon and wait for it to start' '
+	$powermand -c powerman.conf &
+	echo $! >powermand.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -q >/dev/null
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr --diag -q >queryA1.out &&
+	makeoutput "" "t[0-15]" "" >queryA1.exp &&
+	test_cmp queryA1.exp queryA1.out
+'
+test_expect_success 'powerman --diag -1 t[0-15] works' '
+	$powerman -h $testaddr --diag -1 t[0-15] >onA1.out &&
+	echo Command completed successfully >onA1.exp &&
+	test_cmp onA1.exp onA1.out
+'
+test_expect_success 'powerman -q shows all on' '
+	$powerman -h $testaddr --diag -q >queryA2.out &&
+	makeoutput "t[0-15]" "" "" >queryA2.exp &&
+	test_cmp queryA2.exp queryA2.out
+'
+test_expect_success 'powerman -0 t[0-15] works' '
+	$powerman -h $testaddr --diag -0 t[0-15] >offA1.out &&
+	echo Command completed successfully >offA1.exp &&
+	test_cmp offA1.exp offA1.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr --diag -q >queryA3.out &&
+	makeoutput "" "t[0-15]" "" >queryA3.exp &&
+	test_cmp queryA3.exp queryA3.out
+'
+test_expect_success 'powerman --diag -1 t[0-7] works' '
+	$powerman -h $testaddr --diag -1 t[0-7] >onA2.out &&
+	echo Command completed successfully >onA2.exp &&
+	test_cmp onA2.exp onA2.out
+'
+test_expect_success 'powerman -q shows t[0-7] on' '
+	$powerman -h $testaddr --diag -q >queryA4.out &&
+	makeoutput "t[0-7]" "t[8-15]" "" >queryA4.exp &&
+	test_cmp queryA4.exp queryA4.out
+'
+test_expect_success 'powerman -0 t[0-7] works' '
+	$powerman -h $testaddr --diag -0 t[0-7] >offA2.out &&
+	echo Command completed successfully >offA2.exp &&
+	test_cmp offA2.exp offA2.out
+'
+test_expect_success 'powerman -q shows all off' '
+	$powerman -h $testaddr --diag -q >queryA5.out &&
+	makeoutput "" "t[0-15]" "" >queryA5.exp &&
+	test_cmp queryA5.exp queryA5.out
+'
+test_expect_success 'stop powerman daemon' '
+	kill -15 $(cat powermand.pid) &&
+	wait
+'
+
+#
+# t7,t15 set to bad, so will not work with anything below
+#
+
+test_expect_success 'create test powerman.conf' '
+	cat >powerman_bad_plug.conf <<-EOT
+	include "$vpcdev"
+	listen "$testaddr"
+	device "test0" "vpc" "$vpcd --bad-plug=7 --bad-plug=15 |&"
+	node "t[0-15]" "test0"
+	EOT
+'
+test_expect_success 'start powerman daemon and wait for it to start' '
+	$powermand -c powerman_bad_plug.conf &
+	echo $! >powermand.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -q >/dev/null
+'
+test_expect_success 'powerman -q shows t[0-6,8-14] off, t[7,15] unknown' '
+	$powerman -h $testaddr --diag -q >queryBP1.out &&
+	echo t[7,15]: ERROR >queryBP1.exp &&
+	makeoutput "" "t[0-6,8-14]" "t[7,15]" >>queryBP1.exp &&
+	test_cmp queryBP1.exp queryBP1.out
+'
+test_expect_success 'powerman --diag -1 t[0-15] fails' '
+	test_must_fail $powerman -h $testaddr --diag -1 t[0-15] >onBP1.out &&
+	echo t[7,15]: ERROR >onBP1.exp &&
+	echo Command completed with errors >>onBP1.exp &&
+	test_cmp onBP1.exp onBP1.out
+'
+test_expect_success 'powerman -q shows t[0-6,8-14] on, t[7,15] unknown' '
+	$powerman -h $testaddr --diag -q >queryBP2.out &&
+	echo t[7,15]: ERROR >queryBP2.exp &&
+	makeoutput "t[0-6,8-14]" "" "t[7,15]" >>queryBP2.exp &&
+	test_cmp queryBP2.exp queryBP2.out
+'
+test_expect_success 'powerman -0 t[0-15] fails' '
+	test_must_fail $powerman -h $testaddr --diag -0 t[0-15] >offBP1.out &&
+	echo t[7,15]: ERROR >offBP1.exp &&
+	echo Command completed with errors >>offBP1.exp &&
+	test_cmp offBP1.exp offBP1.out
+'
+test_expect_success 'powerman -q shows t[0-6,8-14] off, t[7,15] unknown' '
+	$powerman -h $testaddr --diag -q >queryBP3.out &&
+	echo t[7,15]: ERROR >queryBP3.exp &&
+	makeoutput "" "t[0-6,8-14]" "t[7,15]" >>queryBP3.exp &&
+	test_cmp queryBP3.exp queryBP3.out
+'
+test_expect_success 'powerman --diag -1 t[0-7] fails' '
+	test_must_fail $powerman -h $testaddr --diag -1 t[0-7] >onBP2.out &&
+	echo t7: ERROR >onBP2.exp &&
+	echo Command completed with errors >>onBP2.exp &&
+	test_cmp onBP2.exp onBP2.out
+'
+test_expect_success 'powerman -q shows t[0-6] on' '
+	$powerman -h $testaddr --diag -q >queryBP4.out &&
+	echo t[7,15]: ERROR >queryBP4.exp &&
+	makeoutput "t[0-6]" "t[8-14]" "t[7,15]" >>queryBP4.exp &&
+	test_cmp queryBP4.exp queryBP4.out
+'
+test_expect_success 'powerman -0 t[0-7] fails' '
+	test_must_fail $powerman -h $testaddr --diag -0 t[0-7] >offBP2.out &&
+	echo t7: ERROR >offBP2.exp &&
+	echo Command completed with errors >>offBP2.exp &&
+	test_cmp offBP2.exp offBP2.out
+'
+test_expect_success 'powerman -q shows t[0-6,8-14] off, t[7,15] unknown' '
+	$powerman -h $testaddr --diag -q >queryBP5.out &&
+	echo t[7,15]: ERROR >queryBP5.exp &&
+	makeoutput "" "t[0-6,8-14]" "t[7,15]" >>queryBP5.exp &&
+	test_cmp queryBP5.exp queryBP5.out
+'
+test_expect_success 'stop powerman daemon' '
+	kill -15 $(cat powermand.pid) &&
+	wait
+'
+
+test_done
+
+# vi: set ft=sh


### PR DESCRIPTION
Per discussion in #81, #128, #129

Will split this into multiple PRs later on ... unfortunately all of this had to be done before I even begin to test :P

the series of commits;

- support setplugs command (w/o parents)
- support setpath command
- support plug substitution
- support parents with setplugs config
- support HPE Cray Supercomputing EX chassis device file (hopefully this is the right name)
- lots of new tests and new device files for tests in `t/etc/"

*what parenting does*

If ancestors are all on, then redfishpower can perform power on/off/status on the target.

If ancestor is off, power status is defined as off for all descendants.  Power on/off cannot be done.

As special case, if powering on both ancestors and children (e.g `pm --on cmm,blade0,node[0-1]`), descendants will wait until ancestor power ons are completed first.  This could lead to increase runtime of powerman client b/c of multiple "rounds" of power on and we need bigger timeout.  I chose 100 seconds for time being (need to test).

As special case, if powering off both ancestors and children, descendants will wait until ancestor power offs are complete.  Then by definition, descendants are now all off.

(Just to help differentiate the special cases, there is a difference between `pm --on blade0` and `pm --on cmm0,blade0`, the former will check cmm0 first to determine if blade0 can be turned on.  The latter will turn on cmm0 first, then if that is successful it can then power on blade0)

If any ancestors have status unknown or get an error, that status carries to descendants and results in errors (for status query, that results in "unknown" status).

*annoyances*

Gotta do "%%p" for plug substitution instead of "%p", b/c we're passing a string into redfishpower in which it'll store and parse.  vs most device scripts that is probably using the '%s' as a "format".  This is also one of the reasons I chose "%p" instead of "%s".

*testing*

All testing is done in simulation mode, i need to test on real hardware.  Hopefully it works.  When running in verbose mode, I see the right order of messages going on.

*assumptions*

- with parenting, some code simply assumes no loops possible.  I think is fair assumption to avoid adding excess code for rare case.

- with "%p" substitution, assumes at max one "%p" and no need for "%%" escaping.  I didn't implement a proper "loop through string, look for escape chars" kinda thing.  Seemed excessive given what we actually need.  But maybe I shouldn't have been so lazy.

- if you power on parent, once status of parent is "on", all children can be powered on, no delay is necessary.  But delay wouldn't be too hard to add, "delay code" is already there b/c of status polling delay code.  (note, this "delay" is not in powerman land but in redfishpower land).

- If user does `pm --on cmm0,blade0,node0` and cmm0/blade0 on but node0 not, I just assume redfish protocol will work out (ie sending an "on" will return success that it's already on).  But need to try against real hardware.

*mini concerns*

Due to parent being "off", it is assumed all children are "off", including any node that is missing.  This may not necessarily be what user expects powerman to output.  I think this is acceptable b/c 99% of the time parents on are on (i.e. chassis management head).  It's nodes down below that are typically turned off.  Unfortunately, I think we just have to go with this, as the alternate (send messages to nodes that won't respond) is what we are trying to avoid.  If this is a big deal, we can add some type of "whatsup"-like kinda support, where we can ping in the background and identify those targets as gone/missing.
