### PR TITLE
redfishpower: adjust verbosity output

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -39,7 +39,7 @@ Set Redfish postdata for performing power on.  Typically is {"ResetType":"On"}
 Set Redfish postdata for performing power off.  Typically is {"ResetType":"ForceOff"}
 .TP
 .I "-v, --verbose"
-Increase output verbosity.
+Increase output verbosity.  Can be specified multiple times.
 .SH INTERACTIVE COMMANDS
 The following commands are accepted at the redfishpower> prompt:
 .TP

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -184,7 +184,7 @@ static void powermsg_init_curl(struct powermsg *pm)
     Curl_easy_setopt((pm->eh, CURLOPT_SSL_VERIFYPEER, 0L));
     Curl_easy_setopt((pm->eh, CURLOPT_SSL_VERIFYHOST, 0L));
 
-    if (verbose)
+    if (verbose > 2)
         Curl_easy_setopt((pm->eh, CURLOPT_VERBOSE, 1L));
 
     if (header) {

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -1037,7 +1037,7 @@ int main(int argc, char *argv[])
                     err_exit(true, "hostlist_push error on %s", optarg);
                 break;
             case 'v': /* --verbose */
-                verbose = 1;
+                verbose++;
                 break;
             default:
                 usage();

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -394,8 +394,12 @@ static void parse_onoff_response(struct powermsg *pm, const char **strp)
                     (*strp) = STATUS_ON;
                 else if (strcasecmp(str, "Off") == 0)
                     (*strp) = STATUS_OFF;
-                else
+                else {
                     (*strp) = STATUS_UNKNOWN;
+                    if (verbose)
+                        printf("%s: unknown status - %s\n",
+                               pm->hostname,str);
+                }
             }
         }
         json_decref(o);


### PR DESCRIPTION
splitting off of the big PR as it's rather independent of everything else.

basically the most verbose stuff in redfishpower is output at "level 1" verbosity, which is annoying.  have different levels.
