### PR TITLE
powerman: when status and status_all are defined, use status_all only on full pluglist

### DIFF
--- a/etc/devices/appro-gb2.dev
+++ b/etc/devices/appro-gb2.dev
@@ -44,18 +44,6 @@ specification "sr5110" {
 		}
 		expect "-iSCB> "
 	}
-	script status {
-		send "pmnode %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
-	script status_beacon {
-		send "pmled %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
 	script on {
 		send "power on %s\r"
 		expect "-iSCB> "
@@ -117,18 +105,6 @@ specification "sr5110_gpu" {
 			expect "node([0-9]+): (on|off|n/a)"
 			setplugstate $1 $2 on="on" off="off"
 		}
-		expect "-iSCB> "
-	}
-	script status {
-		send "pmnode %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
-	script status_beacon {
-		send "pmled %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
 		expect "-iSCB> "
 	}
 	script on {
@@ -195,18 +171,6 @@ specification "sr8116" {
 		}
 		expect "-iSCB> "
 	}
-	script status {
-		send "pmnode %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
-	script status_beacon {
-		send "pmled %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
 	script on {
 		send "power on %s\r"
 		expect "-iSCB> "
@@ -270,18 +234,6 @@ specification "sr8116_gpu" {
 		}
 		expect "-iSCB> "
 	}
-	script status {
-		send "pmnode %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
-	script status_beacon {
-		send "pmled %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
 	script on {
 		send "power on %s\r"
 		expect "-iSCB> "
@@ -343,18 +295,6 @@ specification "sr8104" {
 			expect "node([0-9]+): (on|off|n/a)"
 			setplugstate $1 $2 on="on" off="off"
 		}
-		expect "-iSCB> "
-	}
-	script status {
-		send "pmnode %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "-iSCB> "
-	}
-	script status_beacon {
-		send "pmled %s\r"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
 		expect "-iSCB> "
 	}
 	script on {

--- a/etc/devices/appro-greenblade.dev
+++ b/etc/devices/appro-greenblade.dev
@@ -48,20 +48,6 @@ specification "iscb-gb" {
 		expect "ok"
 		expect "iSCB-[0-9]+:[0-9]> "
 	}
-	script status {
-		send "pmnode %s\r\n"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "ok"
-		expect "iSCB-[0-9]+:[0-9]> "
-	}
-	script status_beacon {
-		send "pmled %s\r\n"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "ok"
-		expect "iSCB-[0-9]+:[0-9]> "
-	}
 	script on {
 		send "on %s\r\n"
 		expect "ok"
@@ -138,20 +124,6 @@ specification "iscb-gbgpu" {
 		expect "ok"
 		expect "iSCB-[0-9]+:[0-9]> "
 	}
-	script status {
-		send "pmnode %s\r\n"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "ok"
-		expect "iSCB-[0-9]+:[0-9]> "
-	}
-	script status_beacon {
-		send "pmled %s\r\n"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "ok"
-		expect "iSCB-[0-9]+:[0-9]> "
-	}
 	script on {
 		send "on %s\r\n"
 		expect "ok"
@@ -225,20 +197,6 @@ specification "iscb-hybrid" {
 			expect "node([0-9]+): (on|off|n/a)"
 			setplugstate $1 $2 on="on" off="off"
 		}
-		expect "ok"
-		expect "iSCB-[0-9]+:[0-9]> "
-	}
-	script status {
-		send "pmnode %s\r\n"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "ok"
-		expect "iSCB-[0-9]+:[0-9]> "
-	}
-	script status_beacon {
-		send "pmled %s\r\n"
-		expect "node([0-9]+): (on|off|n/a)"
-		setplugstate $1 $2 on="on" off="off"
 		expect "ok"
 		expect "iSCB-[0-9]+:[0-9]> "
 	}

--- a/etc/devices/swpdu.dev
+++ b/etc/devices/swpdu.dev
@@ -38,12 +38,6 @@ specification "swpdu" {
 		}
 		expect "swpdu> "
 	}
-	script status {
-		send "status %s\r\n"
-		expect "port([0-9]+)[^\n]*(on|off|unknown|^n)"
-		setplugstate $1 $2 on="on" off="off"
-		expect "swpdu> "
-	}
 	script on {
 		send "on %s\r\n"
 		expect "swpdu> "

--- a/man/powerman.dev.5.in
+++ b/man/powerman.dev.5.in
@@ -81,7 +81,11 @@ Get device in a state so login script will work
 (though hopefully disconnecting will do that too).
 .TP
 .I "status_all, status[%s]"
-Obtain plug state for all plugs or only the specified plug.
+Obtain plug state for all plugs or only the specified plug.  In most
+cases, only one script needs to be specified.  In some hardware where
+unpopulated plugs may be problematic, it may be beneficial to specify
+both.  If both scripts are specified, the status_all script will be
+called only when all plug are requested.
 .TP
 .I "on_all, on_ranged[%s], on[%s]"
 Power on all plugs, a range of plugs, or the specified plug.
@@ -107,11 +111,19 @@ and a probe into the node attached to a non-standby power source.
 Obtain temperature reading for all plugs or only the specified plug.
 Temperature is obtained by sampling a thermocouple in the node.
 Results are reported as a text string - not interpreted by Powerman
-beyond any regex chopping done by the script.
+beyond any regex chopping done by the script.  In most cases, only one
+script needs to be specified.  In some hardware where unpopulated
+plugs may be problematic, it may be beneficial to specify both.  If
+both scripts are specified, the status_all script will be called only
+when all plug are requested.
 .TP
 .I "status_beacon_all, status_beacon[%s]"
-Obtain beacon state for all plugs or only the specified plug.
-Some RPC's include a way to flash a light on a node.
+Obtain beacon state for all plugs or only the specified plug.  Some
+RPC's include a way to flash a light on a node.  In most cases, only
+one script needs to be specified.  In some hardware where unpopulated
+plugs may be problematic, it may be beneficial to specify both.  If
+both scripts are specified, the status_all script will be called only
+when all plugs are requested.
 .TP
 .I "beacon_on[%s]"
 Flash beacon on the specified plug.

--- a/src/powerman/device.c
+++ b/src/powerman/device.c
@@ -683,8 +683,12 @@ static int _enqueue_targeted_actions(Device * dev, int com, hostlist_t hl,
     pluglist_iterator_destroy(itr);
 
     /* Try _all version of script.
+     *
+     * - use if action is a query, unless no singlet version exists
+     *   (i.e. if there is no singlet version, we have to use the _all
+     *   version)
      */
-    if (all || _is_query_action(com)) {
+    if (all || (_is_query_action(com) && dev->scripts[com] == NULL)) {
         int ncom = _get_all_script(dev, com);
 
         if (ncom != -1) {

--- a/t/simulators/vpcd.c
+++ b/t/simulators/vpcd.c
@@ -305,6 +305,7 @@ _prompt_loop(void)
                 continue;
             }
             printf("plug %d: %d\n", i, temp[i]);
+            goto ok;
         }
         if (strcmp(buf, "temp *") == 0) {               /* temp * */
             for (i = 0; i < NUM_PLUGS; i++)

--- a/t/t0004-status-query.t
+++ b/t/t0004-status-query.t
@@ -145,6 +145,72 @@ test_expect_success 'stop powerman daemon and device server' '
 	wait &&
 	wait
 '
+test_expect_success 'create new powerman.conf with both status and status_all script' '
+	cat >powerman4.conf <<-EOT4
+	specification "vpc" {
+	    timeout 	5.0
+	    plug name { "0" "1" "2" "3" "4" "5" "6" "7" "8"
+	                "9" "10" "11" "12" "13" "14" "15" }
+	    script login {
+	        send "login\n"
+	        expect "[0-9]* OK\n"
+	        expect "[0-9]* vpc> "
+	    }
+	    script logout {
+	        send "logoff\n"
+	        expect "[0-9]* OK\n"
+	    }
+	    script status {
+	        send "stat %s\n"
+	        expect "plug ([0-9]+): (ON|OFF)\n"
+	        setplugstate \$1 \$2 on="ON" off="OFF"
+	        expect "[0-9]* OK\n"
+	        expect "[0-9]* vpc> "
+	    }
+	    script status_all {
+		send "stat *\n"
+		foreachplug {
+			expect "plug ([0-9]+): (ON|OFF)\n"
+			setplugstate \$1 \$2 on="ON" off="OFF"
+		}
+		expect "[0-9]* OK\n"
+		expect "[0-9]* vpc> "
+	    }
+	}
+	listen "$testaddr"
+	device "test0" "vpc" "$vpcd |&"
+	node "t[0-15]" "test0"
+	EOT4
+'
+test_expect_success 'start powerman daemon and wait for it to start' '
+	$powermand -c powerman4.conf &
+	echo $! >powermand4.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -q >/dev/null
+'
+test_expect_success 'powerman -q works' '
+	$powerman -h $testaddr -q >all_query.out &&
+	makeoutput "" "t[0-15]" "" >all_query.exp &&
+	test_cmp all_query.exp all_query.out
+'
+test_expect_success 'powerman -q uses status_all script on all plugs' '
+	$powerman -h $testaddr -T -q >all_queryT.out &&
+	count=`grep "stat" all_queryT.out | wc -l` &&
+	test $count = 1
+'
+test_expect_success 'powerman -q t[1-15] works' '
+	$powerman -h $testaddr -q t[1-15] >most_query.out &&
+	makeoutput "" "t[1-15]" "" >most_query.exp &&
+	test_cmp most_query.exp most_query.out
+'
+test_expect_success 'powerman -q uses status script on not all plugs' '
+	$powerman -h $testaddr -T -q t[1-15] >most_queryT.out &&
+	count=`grep "stat" most_queryT.out | wc -l` &&
+	test $count = 15
+'
+test_expect_success 'stop powerman daemon' '
+	kill -15 $(cat powermand4.pid) &&
+	wait
+'
 
 test_done
 

--- a/t/t0007-temperature.t
+++ b/t/t0007-temperature.t
@@ -66,6 +66,105 @@ test_expect_success 'stop powerman daemon' '
 	kill -15 $(cat powermand.pid) &&
 	wait
 '
+test_expect_success 'create new powerman.conf with both status_temp and status_temp_all script' '
+	cat >powerman2.conf <<-EOT2
+	specification "vpc" {
+	    timeout 	5.0
+	    plug name { "0" "1" "2" "3" "4" "5" "6" "7" "8"
+	                "9" "10" "11" "12" "13" "14" "15" }
+	    script login {
+	        send "login\n"
+	        expect "[0-9]* OK\n"
+	        expect "[0-9]* vpc> "
+	    }
+	    script logout {
+	        send "logoff\n"
+	        expect "[0-9]* OK\n"
+	    }
+	    script status_temp {
+	        send "temp %s\n"
+	        expect "plug ([0-9]+): ([0-9]+)\n"
+	        setplugstate \$1 \$2
+	        expect "[0-9]* OK\n"
+	        expect "[0-9]* vpc> "
+	    }
+	    script status_temp_all {
+		send "temp *\n"
+		foreachplug {
+			expect "plug ([0-9]+): ([0-9]+)\n"
+			setplugstate \$1 \$2
+		}
+		expect "[0-9]* OK\n"
+		expect "[0-9]* vpc> "
+	    }
+	}
+	listen "$testaddr"
+	device "test0" "vpc" "$vpcd |&"
+	node "t[0-15]" "test0"
+	EOT2
+'
+test_expect_success 'start powerman daemon and wait for it to start' '
+	$powermand -c powerman2.conf &
+	echo $! >powermand2.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -t >/dev/null
+'
+test_expect_success 'powerman -t works' '
+	$powerman -h $testaddr -t >all_query.out &&
+	cat >all_query.exp <<-EOT &&
+	t0: 83
+	t1: 84
+	t2: 85
+	t3: 86
+	t4: 87
+	t5: 88
+	t6: 89
+	t7: 90
+	t8: 91
+	t9: 92
+	t10: 93
+	t11: 94
+	t12: 95
+	t13: 96
+	t14: 97
+	t15: 98
+	EOT
+	test_cmp all_query.exp all_query.out
+'
+test_expect_success 'powerman -t uses temp_status_all script on all plugs' '
+	$powerman -h $testaddr -T -t >all_queryT.out &&
+	count=`grep "temp" all_queryT.out | wc -l` &&
+	test $count = 1
+'
+test_expect_success 'powerman -t t[1-15] works' '
+	$powerman -h $testaddr -t t[1-15] >most_query.out &&
+	cat >most_query.exp <<-EOT &&
+	t1: 84
+	t2: 85
+	t3: 86
+	t4: 87
+	t5: 88
+	t6: 89
+	t7: 90
+	t8: 91
+	t9: 92
+	t10: 93
+	t11: 94
+	t12: 95
+	t13: 96
+	t14: 97
+	t15: 98
+	EOT
+	test_cmp most_query.exp most_query.out
+'
+test_expect_success 'powerman -t uses temp_status script on not all plugs' '
+	$powerman -h $testaddr -T -t t[1-15] >most_queryT.out &&
+	count=`grep "temp" most_queryT.out | wc -l` &&
+	test $count = 15
+'
+test_expect_success 'stop powerman daemon' '
+	kill -15 $(cat powermand2.pid) &&
+	wait
+'
 
 test_done
 


### PR DESCRIPTION
Problem: When selecting a script to use for an action, the "all" version of a script is always used if the action is a query action (e.g. power status query, beacon query, etc.).

This can be problematic in situations where blades/nodes/etc. are not fully populated, such as in a chassis.  We do not want to query "all" things in that case.

Solution: Only call the "all" script if it is a query and a singlet version of the script does not exist.  For device files where unpopulated nodes may exist, it can define an all script and singlet script for each scenario.

Built on top of #155 