### PR TITLE
redfishpower: support setplugs configuration

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -60,6 +60,11 @@ Set path and optional post data to turn on plug.
 .I "setoffpath <path> [postdata]"
 Set path and optional post data to turn off plug.
 .TP
+.I "setplugs plugnames hostindices"
+Associate a plug name with one of the hostnames specified on the
+command line, referred to by its zero origin index Can be called
+multiple times to configure all possible plugs.
+.TP
 .I "settimeout <seconds>"
 Set command timeout in seconds.
 .TP

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -41,7 +41,8 @@ TESTSCRIPTS = \
 	t0030-heartbeat-stonith.t \
 	t0031-llnl-mcr-cluster.t \
 	t0032-list.t \
-	t0033-valgrind.t
+	t0033-valgrind.t \
+	t0034-redfishpower.t
 
 # make check runs these TAP tests directly (both scripts and programs)
 TESTS = \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -60,7 +60,8 @@ EXTRA_DIST= \
 	sharness.sh \
 	etc/sierra_plugs.conf \
 	etc/mcr_plugs.conf \
-	etc/vpc.dev
+	etc/vpc.dev \
+	etc/redfishpower-setplugs.dev
 
 
 AM_CFLAGS = @WARNING_CFLAGS@

--- a/t/etc/redfishpower-setplugs.dev
+++ b/t/etc/redfishpower-setplugs.dev
@@ -1,0 +1,48 @@
+# Variant of redfishpower-cray-r272z30.dev that covers use of setplugs
+# configuration
+specification "redfishpower-setplugs" {
+	timeout 	60
+
+	script login {
+		expect "redfishpower> "
+		send "auth USER:PASS\n"
+		expect "redfishpower> "
+		send "setheader Content-Type:application/json\n"
+		expect "redfishpower> "
+		send "setplugs Node[0-15] [0-15]\n"
+		expect "redfishpower> "
+		send "setstatpath redfish/v1/Systems/Self\n"
+		expect "redfishpower> "
+		send "setonpath redfish/v1/Systems/Self/Actions/ComputerSystem.Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setoffpath redfish/v1/Systems/Self/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setcyclepath redfish/v1/Systems/Self/Actions/ComputerSystem.Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "redfishpower> "
+		send "settimeout 60\n"
+		expect "redfishpower> "
+	}
+	script logout {
+		send "quit\n"
+	}
+	script status_all {
+		send "stat\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setplugstate $1 $2 on="^on\n" off="^off\n"
+		}
+		expect "redfishpower> "
+	}
+	script on_ranged {
+		send "on %s\n"
+		expect "redfishpower> "
+	}
+	script off_ranged {
+		send "off %s\n"
+		expect "redfishpower> "
+	}
+	script cycle_ranged {
+		send "cycle %s\n"
+		expect "redfishpower> "
+	}
+}

--- a/t/t0029-redfish.t
+++ b/t/t0029-redfish.t
@@ -107,43 +107,6 @@ test_expect_success 'stop powerman daemon' '
 	wait
 '
 
-#
-# redfishpower fail hosts coverage
-#
-
-test_expect_success 'create powerman.conf for 16 cray redfish nodes (failhosts)' '
-	cat >powerman_fail_hosts.conf <<-EOT
-	listen "$testaddr"
-	include "$devicesdir/redfishpower-cray-r272z30.dev"
-	device "d0" "redfishpower-cray-r272z30" "$redfishdir/redfishpower -h t[0-15] --test-mode --test-fail-power-cmd-hosts=t[8-15] |&"
-	node "t[0-15]" "d0"
-	EOT
-'
-test_expect_success 'start powerman daemon and wait for it to start (failhosts)' '
-	$powermand -Y -c powerman_fail_hosts.conf &
-	echo $! >powermand.pid &&
-	$powerman --retry-connect=100 --server-host=$testaddr -d
-'
-test_expect_success 'powerman -q shows t[0-7] off, t[8-15] unknown' '
-	$powerman -h $testaddr -q >test_failhosts_query.out &&
-	makeoutput "" "t[0-7]" "t[8-15]" >test_failhosts_query.exp &&
-	test_cmp test_failhosts_query.exp test_failhosts_query.out
-'
-test_expect_success 'powerman -1 t[0-15] completes' '
-	$powerman -h $testaddr -1 t[0-15] >test_failhosts_on.out &&
-	echo Command completed successfully >test_failhosts_on.exp &&
-	test_cmp test_failhosts_on.exp test_failhosts_on.out
-'
-test_expect_success 'powerman -q shows t[0-7] on' '
-	$powerman -h $testaddr -q >test_failhosts_query2.out &&
-	makeoutput "t[0-7]" "" "t[8-15]" >test_failhosts_query2.exp &&
-	test_cmp test_failhosts_query2.exp test_failhosts_query2.out
-'
-test_expect_success 'stop powerman daemon (failhosts)' '
-	kill -15 $(cat powermand.pid) &&
-	wait
-'
-
 test_done
 
 # vi: set ft=sh

--- a/t/t0034-redfishpower.t
+++ b/t/t0034-redfishpower.t
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+test_description='Cover redfishpower specific configurations'
+
+. `dirname $0`/sharness.sh
+
+powermand=$SHARNESS_BUILD_DIRECTORY/src/powerman/powermand
+powerman=$SHARNESS_BUILD_DIRECTORY/src/powerman/powerman
+redfishdir=$SHARNESS_BUILD_DIRECTORY/src/redfishpower
+devicesdir=$SHARNESS_TEST_SRCDIR/../etc/devices
+testdevicesdir=$SHARNESS_TEST_SRCDIR/etc
+
+# Use port = 11000 + test number
+# That way there won't be port conflicts with make -j
+testaddr=localhost:11034
+
+
+makeoutput() {
+	printf "on:      %s\n" $1
+	printf "off:     %s\n" $2
+	printf "unknown: %s\n" $3
+}
+
+#
+# redfishpower fail hosts coverage
+#
+
+test_expect_success 'create powerman.conf for 16 cray redfish nodes (failhosts)' '
+	cat >powerman_fail_hosts.conf <<-EOT
+	listen "$testaddr"
+	include "$devicesdir/redfishpower-cray-r272z30.dev"
+	device "d0" "redfishpower-cray-r272z30" "$redfishdir/redfishpower -h t[0-15] --test-mode --test-fail-power-cmd-hosts=t[8-15] |&"
+	node "t[0-15]" "d0"
+	EOT
+'
+test_expect_success 'start powerman daemon and wait for it to start (failhosts)' '
+	$powermand -Y -c powerman_fail_hosts.conf &
+	echo $! >powermand.pid &&
+	$powerman --retry-connect=100 --server-host=$testaddr -d
+'
+test_expect_success 'powerman -q shows t[0-7] off, t[8-15] unknown' '
+	$powerman -h $testaddr -q >test_failhosts_query.out &&
+	makeoutput "" "t[0-7]" "t[8-15]" >test_failhosts_query.exp &&
+	test_cmp test_failhosts_query.exp test_failhosts_query.out
+'
+test_expect_success 'powerman -1 t[0-15] completes' '
+	$powerman -h $testaddr -1 t[0-15] >test_failhosts_on.out &&
+	echo Command completed successfully >test_failhosts_on.exp &&
+	test_cmp test_failhosts_on.exp test_failhosts_on.out
+'
+test_expect_success 'powerman -q shows t[0-7] on' '
+	$powerman -h $testaddr -q >test_failhosts_query2.out &&
+	makeoutput "t[0-7]" "" "t[8-15]" >test_failhosts_query2.exp &&
+	test_cmp test_failhosts_query2.exp test_failhosts_query2.out
+'
+test_expect_success 'stop powerman daemon (failhosts)' '
+	kill -15 $(cat powermand.pid) &&
+	wait
+'
+
+test_done
+
+# vi: set ft=sh


### PR DESCRIPTION
Problem: In the future it may be convenient to identify hosts
anonymously for easier configuration.  Otherwise, many device
files will have to be created to configure different hosts.

Solution: Support a new setplug config which allows users to map
logical plugs to the indicies of the hosts configured.  For example:

setplugs Node[0-15] [0-15]

This creates a set of plugs named Node[0-15].  These may be used
in place of nodenames input on the command line.

built on top of #156 