### PR TITLE
redfishpower: support setpath configuration 

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -27,16 +27,16 @@ Set extra HEADER to use.  Typically is Content-Type:application/json.
 Set Redfish path for obtaining power status.  Typically is redfish/v1/Systems/1.
 .TP
 .I "-O, --onpath string"
-Set Redfish path for performing power on.  Typically is redfish/v1/Systems/1/Actions/ComputerSystem.Reset.
+Set default Redfish path for performing power on.  Typically is redfish/v1/Systems/1/Actions/ComputerSystem.Reset.
 .TP
 .I "-F, --offpath string"
-Set Redfish path for performing power off.  Typically is redfish/v1/Systems/1/Actions/ComputerSystem.Reset.
+Set default Redfish path for performing power off.  Typically is redfish/v1/Systems/1/Actions/ComputerSystem.Reset.
 .TP
 .I "-P, --onpostdata string"
-Set Redfish postdata for performing power on.  Typically is {"ResetType":"On"}
+Set default Redfish postdata for performing power on.  Typically is {"ResetType":"On"}
 .TP
 .I "-G, --offpostdata string"
-Set Redfish postdata for performing power off.  Typically is {"ResetType":"ForceOff"}
+Set default Redfish postdata for performing power off.  Typically is {"ResetType":"ForceOff"}
 .TP
 .I "-v, --verbose"
 Increase output verbosity.  Can be specified multiple times.
@@ -52,18 +52,21 @@ over the network in plain text.
 Set extra HEADER to use.  Do not specify data to clear.
 .TP
 .I "setstatpath <path>"
-Set path to obtain power status.
+Set default path to obtain power status.
 .TP
 .I "setonpath <path> [postdata]"
-Set path and optional post data to turn on plug.
+Set default path and optional post data to turn on plug.
 .TP
 .I "setoffpath <path> [postdata]"
-Set path and optional post data to turn off plug.
+Set default path and optional post data to turn off plug.
 .TP
 .I "setplugs plugnames hostindices"
 Associate a plug name with one of the hostnames specified on the
 command line, referred to by its zero origin index.  Can be called
 multiple times to configure all possible plugs.
+.TP
+.I "setpath <plugnames> <cmd> <path> [postdata]"
+Set path for specific plug power command ("stat", "on", "off") and optional post data.
 .TP
 .I "settimeout <seconds>"
 Set command timeout in seconds.

--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -62,7 +62,7 @@ Set path and optional post data to turn off plug.
 .TP
 .I "setplugs plugnames hostindices"
 Associate a plug name with one of the hostnames specified on the
-command line, referred to by its zero origin index Can be called
+command line, referred to by its zero origin index.  Can be called
 multiple times to configure all possible plugs.
 .TP
 .I "settimeout <seconds>"

--- a/src/redfishpower/Makefile.am
+++ b/src/redfishpower/Makefile.am
@@ -9,6 +9,7 @@ sbin_PROGRAMS = redfishpower
 
 redfishpower_SOURCES = \
 	redfishpower.c \
+	redfishpower_defs.h \
 	plugs.h \
 	plugs.c
 

--- a/src/redfishpower/plugs.c
+++ b/src/redfishpower/plugs.c
@@ -43,6 +43,11 @@ static void plug_data_destroy(struct plug_data *pd)
     if (pd) {
         xfree(pd->plugname);
         xfree(pd->hostname);
+        xfree(pd->stat);
+        xfree(pd->on);
+        xfree(pd->onpostdata);
+        xfree(pd->off);
+        xfree(pd->offpostdata);
         xfree(pd);
     }
 }
@@ -111,6 +116,51 @@ struct plug_data *plugs_get_data(plugs_t *p, const char *plugname)
 hostlist_t *plugs_hostlist(plugs_t *p)
 {
     return &p->plugs;
+}
+
+int plugs_update_path(plugs_t *p,
+                      const char *plugname,
+                      const char *cmd,
+                      const char *path,
+                      const char *postdata)
+{
+    struct plug_data *pd;
+    char **cmdptr = NULL;
+    char **postdataptr = NULL;
+
+    if (!(pd = plugs_get_data(p, plugname)))
+        return -1;
+
+    if (strcmp(cmd, CMD_STAT) == 0) {
+        cmdptr = &pd->stat;
+    }
+    else if (strcmp(cmd, CMD_ON) == 0) {
+        cmdptr = &pd->on;
+        postdataptr = &pd->onpostdata;
+    }
+    else if (strcmp(cmd, CMD_OFF) == 0) {
+        cmdptr = &pd->off;
+        postdataptr = &pd->offpostdata;
+    }
+    else
+        return -1;
+
+    if (*cmdptr) {
+        free(*cmdptr);
+        (*cmdptr) = NULL;
+    }
+    if (postdataptr && *postdataptr) {
+        free(*postdataptr);
+        (*postdataptr) = NULL;
+    }
+
+    if (path) {
+        (*cmdptr) = xstrdup(path);
+        if (postdataptr && postdata)
+            (*postdataptr) = xstrdup(postdata);
+    }
+
+    return 0;
 }
 
 int plugs_name_valid(plugs_t *p, const char *plugname)

--- a/src/redfishpower/plugs.c
+++ b/src/redfishpower/plugs.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include "redfishpower_defs.h"
 #include "plugs.h"
 
 #include "xmalloc.h"

--- a/src/redfishpower/plugs.h
+++ b/src/redfishpower/plugs.h
@@ -16,6 +16,15 @@
 struct plug_data {
     char *plugname;
     char *hostname;
+
+    /* paths */
+    char *stat;
+    char *on;
+    char *onpostdata;
+    char *off;
+    char *offpostdata;
+    char *cycle;
+    char *cyclepostdata;
 };
 
 typedef struct plugs plugs_t;
@@ -33,6 +42,12 @@ int plugs_count(plugs_t *p);
 struct plug_data *plugs_get_data(plugs_t *p, const char *plugname);
 
 hostlist_t *plugs_hostlist(plugs_t *p);
+
+int plugs_update_path(plugs_t *p,
+                      const char *plugname,
+                      const char *cmd,
+                      const char *path,
+                      const char *postdata);
 
 int plugs_name_valid(plugs_t *p, const char *plugname);
 

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <assert.h>
 
+#include "redfishpower_defs.h"
 #include "plugs.h"
 
 #include "xmalloc.h"
@@ -75,10 +76,6 @@ static zhashx_t *test_power_status;
 #define STATUS_POLLING_INTERVAL_DEFAULT  1000000
 
 #define MS_IN_SEC                1000
-
-#define CMD_STAT       "stat"
-#define CMD_ON         "on"
-#define CMD_OFF        "off"
 
 #define STATUS_ON           "on"
 #define STATUS_OFF          "off"

--- a/src/redfishpower/redfishpower_defs.h
+++ b/src/redfishpower/redfishpower_defs.h
@@ -1,0 +1,22 @@
+/************************************************************\
+ * Copyright (C) 2024 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
+#ifndef REDFISHPOWER_DEFS_H
+#define REDFISHPOWER_DEFS_H
+
+#define CMD_STAT       "stat"
+#define CMD_ON         "on"
+#define CMD_OFF        "off"
+
+#endif /* REDFISHPOWER_DEFS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/redfishpower/test/plugs.c
+++ b/src/redfishpower/test/plugs.c
@@ -98,11 +98,81 @@ static void basic_tests(void)
     plugs_destroy(p);
 }
 
+static void path_tests(void)
+{
+    plugs_t *p;
+    struct plug_data *pd;
+    int ret;
+
+    p = plugs_create();
+    if (!p)
+        BAIL_OUT("plugs_create");
+
+    plugs_add(p, "blade0", "node0");
+    plugs_add(p, "blade1", "node1");
+
+    ret = plugs_update_path(p, "blade0", "stat", "statpath0", NULL);
+    ok(ret == 0,
+       "plugs_update_path of stat path works on blade0");
+    ret = plugs_update_path(p, "blade0", "on", "onpath0", "onpostdata0");
+    ok(ret == 0,
+       "plugs_update_path of on path works on blade0");
+    /* intionally leave no postdata for off for testing */
+    ret = plugs_update_path(p, "blade0", "off", "offpath0", NULL);
+    ok(ret == 0,
+       "plugs_update_path of off path works on blade0");
+
+    ret = plugs_update_path(p, "blade1", "stat", "statpath1", NULL);
+    ok(ret == 0,
+       "plugs_update_path of stat path works on blade1");
+    ret = plugs_update_path(p, "blade1", "on", "onpath1", "onpostdata1");
+    ok(ret == 0,
+       "plugs_update_path of on path works on blade1");
+    /* intionally leave no postdata for off for testing */
+    ret = plugs_update_path(p, "blade1", "off", "offpath1", NULL);
+    ok(ret == 0,
+       "plugs_update_path of off path works on blade1");
+
+    ret = plugs_update_path(p, "foof", "stat", "statpath", NULL);
+    ok(ret == -1,
+       "plugs_update_path of invalid plug fails");
+    ret = plugs_update_path(p, "blade0", "foof", "statpath", NULL);
+    ok(ret == -1,
+       "plugs_update_path of invalid cmd fails");
+
+    pd = plugs_get_data(p, "blade0");
+    ok(strcmp(pd->stat, "statpath0") == 0,
+       "blade0 has correct stat path");
+    ok(strcmp(pd->on, "onpath0") == 0,
+       "blade0 has correct on path");
+    ok(strcmp(pd->onpostdata, "onpostdata0") == 0,
+       "blade0 has correct on postdata");
+    ok(strcmp(pd->off, "offpath0") == 0,
+       "blade0 has correct off path");
+    ok(pd->offpostdata == NULL,
+       "blade0 has no off postdata");
+
+    pd = plugs_get_data(p, "blade1");
+    ok(strcmp(pd->stat, "statpath1") == 0,
+       "blade1 has correct stat path");
+    ok(strcmp(pd->on, "onpath1") == 0,
+       "blade1 has correct on path");
+    ok(strcmp(pd->onpostdata, "onpostdata1") == 0,
+       "blade1 has correct on postdata");
+    ok(strcmp(pd->off, "offpath1") == 0,
+       "blade1 has correct off path");
+    ok(pd->offpostdata == NULL,
+       "blade1 has no off postdata");
+
+    plugs_destroy(p);
+}
+
 int main(int argc, char *argv[])
 {
     plan(NO_PLAN);
 
     basic_tests();
+    path_tests();
 
     done_testing();
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -61,7 +61,8 @@ EXTRA_DIST= \
 	etc/sierra_plugs.conf \
 	etc/mcr_plugs.conf \
 	etc/vpc.dev \
-	etc/redfishpower-setplugs.dev
+	etc/redfishpower-setplugs.dev \
+	etc/redfishpower-setpath.dev
 
 
 AM_CFLAGS = @WARNING_CFLAGS@

--- a/t/etc/redfishpower-setpath.dev
+++ b/t/etc/redfishpower-setpath.dev
@@ -1,0 +1,70 @@
+# Variant of redfishpower-cray-r272z30.dev that covers use of setplugs
+# and setpath configuration
+#
+# Notes:
+# - for easier grepping in tests, simplify paths
+# - different paths for different chunks of nodes/plugs
+# - no plug specific paths set for Node[10-15], will use defaults
+#   set via setstatpath, setonpath, etc.
+specification "redfishpower-setpath" {
+	timeout 	60
+
+	script login {
+		expect "redfishpower> "
+		send "auth USER:PASS\n"
+		expect "redfishpower> "
+		send "setheader Content-Type:application/json\n"
+		expect "redfishpower> "
+		send "setplugs Node[0-15] [0-15]\n"
+		expect "redfishpower> "
+		send "setpath Node[0-4] stat redfish/Group0\n"
+		expect "redfishpower> "
+		send "setpath Node[0-4] on redfish/Group0/Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-4] off redfish/Group0/Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-4] cycle redfish/Group0/Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[5-9] stat redfish/Group1\n"
+		expect "redfishpower> "
+		send "setpath Node[5-9] on redfish/Group1/Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[5-9] off redfish/Group1/Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[5-9] cycle redfish/Group1/Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "redfishpower> "
+		send "setstatpath redfish/Default\n"
+		expect "redfishpower> "
+		send "setonpath redfish/Default/Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setoffpath redfish/Default/Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setcyclepath redfish/Default/Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "redfishpower> "
+		send "settimeout 60\n"
+		expect "redfishpower> "
+	}
+	script logout {
+		send "quit\n"
+	}
+	script status_all {
+		send "stat\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setplugstate $1 $2 on="^on\n" off="^off\n"
+		}
+		expect "redfishpower> "
+	}
+	script on_ranged {
+		send "on %s\n"
+		expect "redfishpower> "
+	}
+	script off_ranged {
+		send "off %s\n"
+		expect "redfishpower> "
+	}
+	script cycle_ranged {
+		send "cycle %s\n"
+		expect "redfishpower> "
+	}
+}


### PR DESCRIPTION
Problem: Currently in redfishpower, a single global setting for
stat, on, off, and cycle paths is configured for all hosts.  This
may not be convenient for some environments, where some specific
hosts need to have different paths for power operations.

Support a new configuration "setpath" that can set paths for
specific hosts.  The remaining configurations remain in place
to configure the "defaults".

Built on top of #157 