### PR TITLE
redfishpower: support plug substitution

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -62,11 +62,15 @@ Set default path and optional post data to turn off plug.
 .TP
 .I "setplugs plugnames hostindices"
 Associate a plug name with one of the hostnames specified on the
-command line, referred to by its zero origin index.  Can be called
-multiple times to configure all possible plugs.
+command line, referred to by its zero origin index. Can be called
+multiple times to configure all possible plugs.  In most
+cases the number of plugs should equal the number of indices.
+Multiple plugs can be mapped to a single host index, which is typically
+used along with plug substitution (see "setpath" command below).
 .TP
 .I "setpath <plugnames> <cmd> <path> [postdata]"
 Set path for specific plug power command ("stat", "on", "off") and optional post data.
+The plug name can be substituted into the URI path by specifying "{{plug}}" in the path.
 .TP
 .I "settimeout <seconds>"
 Set command timeout in seconds.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -62,7 +62,9 @@ EXTRA_DIST= \
 	etc/mcr_plugs.conf \
 	etc/vpc.dev \
 	etc/redfishpower-setplugs.dev \
-	etc/redfishpower-setpath.dev
+	etc/redfishpower-setpath.dev \
+	etc/redfishpower-plugsub.dev \
+	etc/redfishpower-plugsub-blades.dev
 
 
 AM_CFLAGS = @WARNING_CFLAGS@

--- a/t/etc/redfishpower-plugsub-blades.dev
+++ b/t/etc/redfishpower-plugsub-blades.dev
@@ -1,0 +1,54 @@
+# Variant of redfishpower-cray-r272z30.dev that covers use of plug
+# substitution and the assumption of blades.
+#
+# Notes:
+# - hypothetical blades go through Node0
+# - for easier grepping in tests, simplify paths
+specification "redfishpower-plugsub-blades" {
+	timeout 	60
+
+	script login {
+		expect "redfishpower> "
+		send "auth USER:PASS\n"
+		expect "redfishpower> "
+		send "setheader Content-Type:application/json\n"
+		expect "redfishpower> "
+		send "setplugs Node[0-15] [0-15]\n"
+		expect "redfishpower> "
+		send "setplugs Blade[0-3] 0\n"
+		expect "redfishpower> "
+		send "setstatpath redfish/Default-{{plug}}/Stat\n"
+		expect "redfishpower> "
+		send "setonpath redfish/Default-{{plug}}/Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setoffpath redfish/Default-{{plug}}/Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setcyclepath redfish/Default-{{plug}}/Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "redfishpower> "
+		send "settimeout 60\n"
+		expect "redfishpower> "
+	}
+	script logout {
+		send "quit\n"
+	}
+	script status_all {
+		send "stat\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setplugstate $1 $2 on="^on\n" off="^off\n"
+		}
+		expect "redfishpower> "
+	}
+	script on_ranged {
+		send "on %s\n"
+		expect "redfishpower> "
+	}
+	script off_ranged {
+		send "off %s\n"
+		expect "redfishpower> "
+	}
+	script cycle_ranged {
+		send "cycle %s\n"
+		expect "redfishpower> "
+	}
+}

--- a/t/etc/redfishpower-plugsub.dev
+++ b/t/etc/redfishpower-plugsub.dev
@@ -1,0 +1,62 @@
+# Variant of redfishpower-cray-r272z30.dev that covers use of plug
+# substitution.
+#
+# Notes:
+# - for easier grepping in tests, simplify paths
+# - different paths for different chunks of nodes/plugs
+# - no plug specific paths set for Node[8-15], will use defaults
+#   set via setstatpath, setonpath, etc.
+specification "redfishpower-plugsub" {
+	timeout 	60
+
+	script login {
+		expect "redfishpower> "
+		send "auth USER:PASS\n"
+		expect "redfishpower> "
+		send "setheader Content-Type:application/json\n"
+		expect "redfishpower> "
+		send "setplugs Node[0-15] [0-15]\n"
+		expect "redfishpower> "
+		send "setpath Node[0-7] stat redfish/Group0\n"
+		expect "redfishpower> "
+		send "setpath Node[0-7] on redfish/Group0-{{plug}}/Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-7] off redfish/Group0-{{plug}}/Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setpath Node[0-7] cycle redfish/Group0-{{plug}}/Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "redfishpower> "
+		send "setstatpath redfish/Default\n"
+		expect "redfishpower> "
+		send "setonpath redfish/Default-{{plug}}/Reset {\"ResetType\":\"On\"}\n"
+		expect "redfishpower> "
+		send "setoffpath redfish/Default-{{plug}}/Reset {\"ResetType\":\"ForceOff\"}\n"
+		expect "redfishpower> "
+		send "setcyclepath redfish/Default-{{plug}}/Reset {\"ResetType\":\"ForceRestart\"}\n"
+		expect "redfishpower> "
+		send "settimeout 60\n"
+		expect "redfishpower> "
+	}
+	script logout {
+		send "quit\n"
+	}
+	script status_all {
+		send "stat\n"
+		foreachnode {
+			expect "([^\n:]+): ([^\n]+\n)"
+			setplugstate $1 $2 on="^on\n" off="^off\n"
+		}
+		expect "redfishpower> "
+	}
+	script on_ranged {
+		send "on %s\n"
+		expect "redfishpower> "
+	}
+	script off_ranged {
+		send "off %s\n"
+		expect "redfishpower> "
+	}
+	script cycle_ranged {
+		send "cycle %s\n"
+		expect "redfishpower> "
+	}
+}


### PR DESCRIPTION
Problem: In some chassis, power status/control URIs are all
minorly different from each other when doing power status/control
to blades.  This makes it difficult to configure powerman/redfishpower
for bladed environments.

Solution: Support plug substitution in URIs with the pattern %p.
By using plug names that are the minor variants of each URI, paths
can be easily configured for each blade in a chassis.  This now allows
the setplugs command to map mutiple plug names to a single index.

Fixes #129

Built on top of #158