### PR TITLE
redfishpower: refactor internals to use plugs

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -55,22 +55,22 @@ Set extra HEADER to use.  Do not specify data to clear.
 Set path to obtain power status.
 .TP
 .I "setonpath <path> [postdata]"
-Set path and optional post data to turn on node.
+Set path and optional post data to turn on plug.
 .TP
 .I "setoffpath <path> [postdata]"
-Set path and optional post data to turn off node.
+Set path and optional post data to turn off plug.
 .TP
 .I "settimeout <seconds>"
 Set command timeout in seconds.
 .TP
-.I "stat [nodes]"
-Get power status of all nodes or specified subset of nodes.
+.I "stat [plugs]"
+Get power status of all plugs or specified subset of plugs.
 .TP
-.I "on [nodes]"
-Turn on all nodes or specified subset of nodes.  Will return "ok" after confirmation "on" has completed.
+.I "on [plugs]"
+Turn on all plugs or specified subset of plugs.  Will return "ok" after confirmation "on" has completed.
 .TP
-.I "off [nodes]"
-Turn off all nodes or specified subset of nodes.  Will return "ok" after confirmation "off" has completed.
+.I "off [plugs]"
+Turn off all plugs or specified subset of plugs.  Will return "ok" after confirmation "off" has completed.
 
 .SH "UPDATING REDFISHPOWER DEVICE FILES"
 .LP

--- a/src/libcommon/test/argv.c
+++ b/src/libcommon/test/argv.c
@@ -21,21 +21,21 @@
 int
 main(int argc, char *argv[])
 {
-	char **av;
+    char **av;
 
-	plan(NO_PLAN);
+    plan(NO_PLAN);
 
-	av = argv_create("foo bar baz", "");
-	ok (av != NULL,
+    av = argv_create("foo bar baz", "");
+    ok (av != NULL,
         "argv_create foo bar baz works");
     ok (argv_length(av) == 3,
         "argv_length returns 3");
-	av = argv_append(av, "bonk");
+    av = argv_append(av, "bonk");
     ok (argv_length(av) == 4,
         "argv_length returns 4");
     is (av[0], "foo",
         "first arg is foo");
-	is (av[1], "bar",
+    is (av[1], "bar",
         "second arg is bar");
     is (av[2], "baz",
         "third arg is baz");
@@ -43,27 +43,27 @@ main(int argc, char *argv[])
         "fourth arg is bonk");
     ok (av[4] == NULL,
         "vector is NULL terminated");
-	argv_destroy(av);
+    argv_destroy(av);
 
-	av = argv_create("a,b:c d", ",:");
-	ok (av != NULL,
+    av = argv_create("a,b:c d", ",:");
+    ok (av != NULL,
         "argv_create a,:c d with , and : separators works");
-	ok (argv_length(av) == 4,
+    ok (argv_length(av) == 4,
         "argv_length is 4");
-	is (av[0], "a",
+    is (av[0], "a",
         "first arg is a");
-	is (av[1], "b",
+    is (av[1], "b",
         "second arg is b");
-	is (av[2], "c",
+    is (av[2], "c",
         "third arg is c");
-	is (av[3], "d",
+    is (av[3], "d",
         "fourth arg is d");
-	ok (av[4] == NULL,
+    ok (av[4] == NULL,
         "vector is null terminated");
-	argv_destroy(av);
+    argv_destroy(av);
 
-	done_testing();
-	exit(0);
+    done_testing();
+    exit(0);
 }
 
 // vi:ts=4 sw=4 expandtab

--- a/src/libcommon/test/xregex.c
+++ b/src/libcommon/test/xregex.c
@@ -25,25 +25,25 @@
 static bool
 _matchstr(char *r, char *s, char *p)
 {
-	xregex_t re;
-	xregex_match_t rm;
-	int res;
-	char *tmp;
+    xregex_t re;
+    xregex_match_t rm;
+    int res;
+    char *tmp;
 
-	re = xregex_create();
-	rm = xregex_match_create(2);
-	xregex_compile(re, r, true);
-	res = xregex_exec(re, s, rm);
-	if (res && p) {
-		tmp = xregex_match_strdup(rm);
-		if (strcmp(tmp, p) != 0)
-			res = false;
-		xfree(tmp);
-	}
-	xregex_match_destroy(rm);
-	xregex_destroy(re);
+    re = xregex_create();
+    rm = xregex_match_create(2);
+    xregex_compile(re, r, true);
+    res = xregex_exec(re, s, rm);
+    if (res && p) {
+        tmp = xregex_match_strdup(rm);
+        if (strcmp(tmp, p) != 0)
+            res = false;
+        xfree(tmp);
+    }
+    xregex_match_destroy(rm);
+    xregex_destroy(re);
 
-	return res;
+    return res;
 }
 
 /* Return true if regex [r] matches exactly [s] in [s].
@@ -51,7 +51,7 @@ _matchstr(char *r, char *s, char *p)
 static bool
 _matchstr_all(char *r, char *s)
 {
-	return _matchstr(r, s, s);
+    return _matchstr(r, s, s);
 }
 
 /* Return true if regex [r] matches anything in [s].
@@ -59,195 +59,195 @@ _matchstr_all(char *r, char *s)
 static bool
 _match(char *r, char *s)
 {
-	return _matchstr(r, s, NULL);
+    return _matchstr(r, s, NULL);
 }
 
 static void
 _check_substr_match(void)
 {
-	xregex_t re;
-	xregex_match_t rm;
-	char *s;
+    xregex_t re;
+    xregex_match_t rm;
+    char *s;
 
-	re = xregex_create();
-	rm = xregex_match_create(2);
+    re = xregex_create();
+    rm = xregex_match_create(2);
 
-	xregex_compile(re, "foo([0-9]+)bar([0-9]+)", true);
-	ok (xregex_exec(re, "xxxfoo1bar2", rm) == true,
+    xregex_compile(re, "foo([0-9]+)bar([0-9]+)", true);
+    ok (xregex_exec(re, "xxxfoo1bar2", rm) == true,
         "regex with substrings matches xxxfoo1bar2");
 
-	s = xregex_match_sub_strdup(rm, 0);
-	ok (s != NULL,
+    s = xregex_match_sub_strdup(rm, 0);
+    ok (s != NULL,
         "substring 0 matched");
-	is (s, "foo1bar2",
+    is (s, "foo1bar2",
         "substring 0 is foo1bar2");
-	xfree(s);
+    xfree(s);
 
-	s = xregex_match_sub_strdup(rm, 1);
-	ok (s != NULL,
+    s = xregex_match_sub_strdup(rm, 1);
+    ok (s != NULL,
         "substring 1 matched");
-	is (s, "1",
+    is (s, "1",
         "substring 1 is 1");
-	xfree(s);
+    xfree(s);
 
-	s = xregex_match_sub_strdup(rm, 2);
-	ok (s != NULL,
+    s = xregex_match_sub_strdup(rm, 2);
+    ok (s != NULL,
         "substring 2 matched");
-	is (s, "2",
+    is (s, "2",
         "substring 2 is 2");
-	xfree(s);
+    xfree(s);
 
-	s = xregex_match_sub_strdup(rm, 3);
-	ok (s == NULL,
+    s = xregex_match_sub_strdup(rm, 3);
+    ok (s == NULL,
         "substring 4 did NOT match");
 
-	s = xregex_match_sub_strdup(rm, -1); /* powerman actually does this! */
-	ok (s == NULL,
+    s = xregex_match_sub_strdup(rm, -1); /* powerman actually does this! */
+    ok (s == NULL,
         "substring -1 did NOT match");
 
-	s = xregex_match_strdup(rm);
-	is (s, "xxxfoo1bar2",
+    s = xregex_match_strdup(rm);
+    is (s, "xxxfoo1bar2",
         "overall match is xxxfoo1bar2");
 
-	ok (xregex_match_strlen(rm) == strlen(s),
+    ok (xregex_match_strlen(rm) == strlen(s),
         "xregex_match_strlen returns expected length");
-	xfree(s);
+    xfree(s);
 
-	xregex_match_recycle(rm);
+    xregex_match_recycle(rm);
 
-	ok (xregex_exec(re, "foobar2", rm) == false,
+    ok (xregex_exec(re, "foobar2", rm) == false,
         "regex does NOT match foobar2");
 
-	s = xregex_match_sub_strdup(rm, 0);
-	ok (s == NULL,
+    s = xregex_match_sub_strdup(rm, 0);
+    ok (s == NULL,
         "substring 0 did NOT match");
-	s = xregex_match_sub_strdup(rm, 1);
-	ok (s == NULL,
+    s = xregex_match_sub_strdup(rm, 1);
+    ok (s == NULL,
         "substring 1 did NOT match");
 
-	xregex_match_recycle(rm);
+    xregex_match_recycle(rm);
 
-	ok (xregex_exec(re, "xxxfoo1bar2yyy", rm) == true,
+    ok (xregex_exec(re, "xxxfoo1bar2yyy", rm) == true,
         "regex does matches xxxfoo1bar2yyy");
 
-	s = xregex_match_sub_strdup(rm, 0);
-	ok (s != NULL,
+    s = xregex_match_sub_strdup(rm, 0);
+    ok (s != NULL,
         "substring 0 matched");
-	is (s, "foo1bar2",
+    is (s, "foo1bar2",
         "substring 0 is foo1bar2");
-	xfree(s);
+    xfree(s);
 
-	s = xregex_match_sub_strdup(rm, 1);
-	ok (s != NULL,
+    s = xregex_match_sub_strdup(rm, 1);
+    ok (s != NULL,
         "substring 1 matched");
-	is (s, "1",
+    is (s, "1",
         "substring 1 is 1");
-	xfree(s);
+    xfree(s);
 
-	s = xregex_match_sub_strdup(rm, 2);
-	ok (s != NULL,
+    s = xregex_match_sub_strdup(rm, 2);
+    ok (s != NULL,
         "substring 2 matched");
-	is (s, "2",
+    is (s, "2",
         "substring 2 is 2");
-	xfree(s);
+    xfree(s);
 
-	s = xregex_match_strdup(rm);
-	is (s, "xxxfoo1bar2",
+    s = xregex_match_strdup(rm);
+    is (s, "xxxfoo1bar2",
         "overall match is xxxfoo1bar2");
-	ok (xregex_match_strlen(rm) == strlen(s),
+    ok (xregex_match_strlen(rm) == strlen(s),
         "xregex_match_strlen returned expected length");
-	xfree(s);
+    xfree(s);
 
-	xregex_match_destroy(rm);
-	xregex_destroy(re);
+    xregex_match_destroy(rm);
+    xregex_destroy(re);
 }
 
 int
 main(int argc, char *argv[])
 {
-	char *s;
+    char *s;
 
-	plan(NO_PLAN);
+    plan(NO_PLAN);
 
-	ok (_match("foo", "foo"),
+    ok (_match("foo", "foo"),
         "regex foo matches foo");
-	ok (_match("foo", "fooxxx"),
+    ok (_match("foo", "fooxxx"),
         "regex foo matches fooxxx");
-	ok (_match("foo", "xxxfoo"),
+    ok (_match("foo", "xxxfoo"),
         "regex foo matches xxxfoo");
-	ok (!_match("foo", "bar"),
+    ok (!_match("foo", "bar"),
         "regex foo does NOT match bar");
 
-	_check_substr_match();
+    _check_substr_match();
 
-	/* verify that \\n and \\r are converted into \r and \r */
-	ok (!_match("foo\\r\\n", "foo\\r\\n"),
+    /* verify that \\n and \\r are converted into \r and \r */
+    ok (!_match("foo\\r\\n", "foo\\r\\n"),
         "regex foo\\\\r\\\\n matches foo\\\\r\\\\n");
-	ok ( _match("foo\\r\\n", "foo\r\n"),
+    ok ( _match("foo\\r\\n", "foo\r\n"),
         "regex foo\\\\r\\\\n does NOT match foo\\r\\n");
 
-	/* check a really long string for a regex */
-#define LONG_STR_LEN 	(64*1024*1024)
-#define POS_MAGIC 	42
-#define POS_WONDERFUL	32*1024*1024
-#define POS_COOKIE	63*1024*1024
-	s = xmalloc(LONG_STR_LEN);
-	memset(s, 'a', LONG_STR_LEN - 1);
-	memcpy(s + POS_MAGIC,     "MAGIC",     5);
-	memcpy(s + POS_WONDERFUL, "WONDERFUL", 9);
-	memcpy(s + POS_COOKIE,    "COOKIE",    6);
-	s[LONG_STR_LEN - 1] = '\0';
-	ok (_match("MAGIC", s),
+    /* check a really long string for a regex */
+#define LONG_STR_LEN    (64*1024*1024)
+#define POS_MAGIC   42
+#define POS_WONDERFUL   32*1024*1024
+#define POS_COOKIE  63*1024*1024
+    s = xmalloc(LONG_STR_LEN);
+    memset(s, 'a', LONG_STR_LEN - 1);
+    memcpy(s + POS_MAGIC,     "MAGIC",     5);
+    memcpy(s + POS_WONDERFUL, "WONDERFUL", 9);
+    memcpy(s + POS_COOKIE,    "COOKIE",    6);
+    s[LONG_STR_LEN - 1] = '\0';
+    ok (_match("MAGIC", s),
         "regex MAGIC matched %d bytes into a string", POS_MAGIC);
-	ok (_match("WONDERFUL", s),
+    ok (_match("WONDERFUL", s),
         "regex WONDERFUL matched %d bytes into a string", POS_WONDERFUL);
-	ok (_match("COOKIE", s),
+    ok (_match("COOKIE", s),
         "regex COOKIE matched %d bytes into a string", POS_COOKIE);
-	ok (!_match("CHOCOLATE", s),
+    ok (!_match("CHOCOLATE", s),
         "regex CHOCOLATE did NOT match in that long string");
-	xfree(s);
+    xfree(s);
 
-	/* end of line handling should be disabled since end of string
-	 * (which normally matches) is non-deterministic in powerman.
-	 * We should be explicitly matching end-of-line sentinels like
-	 * \n in scripts.
-	 */
+    /* end of line handling should be disabled since end of string
+     * (which normally matches) is non-deterministic in powerman.
+     * We should be explicitly matching end-of-line sentinels like
+     * \n in scripts.
+     */
     ok (!_match("foo$", "foo"),
         "regex foo$ did NOT match foo");
-	ok (!_match("foo$", "foo\n"),
+    ok (!_match("foo$", "foo\n"),
         "regex foo$ did NOT match foo\\n");
-	ok (!_match("foo\n", "foo"),
+    ok (!_match("foo\n", "foo"),
         "regex foo\\n did NOT match foo");
-	ok (!_match("foo\n", "bar\nfoo"),
+    ok (!_match("foo\n", "bar\nfoo"),
         "regex foo\\n did NOT match bar\\nfoo");
-	ok (_match("foo\n", "barfoo\n"),
+    ok (_match("foo\n", "barfoo\n"),
         "regex foo\\n matched barfoo\\n");
 
-	/* regex takes first match if there are > 1,
-	 * but leading wildcard matches greedily
-	 */
-	ok (_matchstr("foo", "abfoocdfoo", "abfoo"),
+    /* regex takes first match if there are > 1,
+     * but leading wildcard matches greedily
+     */
+    ok (_matchstr("foo", "abfoocdfoo", "abfoo"),
         "regex takes first match if there are more than one");
-	ok (_matchstr_all(".*foo", "abfoocdfoo"),
+    ok (_matchstr_all(".*foo", "abfoocdfoo"),
         "leading wildcard matches greedily");
 
-	/* check that [:space:] character class works inside bracket
-	 * expression
-	 */
-	ok (_matchstr_all("bar[0-9[:space:]]*foo", "bar  42  foo"),
+    /* check that [:space:] character class works inside bracket
+     * expression
+     */
+    ok (_matchstr_all("bar[0-9[:space:]]*foo", "bar  42  foo"),
         "[:space:] character class works inside bracket expression");
 
-	/* debug apcpdu3 regex
-	 */
+    /* debug apcpdu3 regex
+     */
 #define B3RX "([0-9])*[^\r\n]*(ON|OFF)\r\n"
-	ok (_matchstr_all(B3RX, "     2- Outlet 2                 ON\r\n"),
+    ok (_matchstr_all(B3RX, "     2- Outlet 2                 ON\r\n"),
         "apcpdu3 regex test 1 works");
-	ok (_matchstr_all(B3RX, "     9-                          ON\r\n"),
+    ok (_matchstr_all(B3RX, "     9-                          ON\r\n"),
         "apcpdu3 regex test 2 works");
 
-	done_testing();
+    done_testing();
 
-	exit(0);
+    exit(0);
 }
 
 // vi:ts=4 sw=4 expandtab

--- a/src/redfishpower/Makefile.am
+++ b/src/redfishpower/Makefile.am
@@ -7,7 +7,11 @@ AM_CPPFLAGS = \
 
 sbin_PROGRAMS = redfishpower
 
-redfishpower_SOURCES = redfishpower.c
+redfishpower_SOURCES = \
+	redfishpower.c \
+	plugs.h \
+	plugs.c
+
 redfishpower_LDADD = \
 	$(top_builddir)/src/liblsd/liblsd.la \
 	$(top_builddir)/src/libczmq/libczmq.la \

--- a/src/redfishpower/Makefile.am
+++ b/src/redfishpower/Makefile.am
@@ -18,3 +18,22 @@ redfishpower_LDADD = \
 	$(top_builddir)/src/libcommon/libcommon.la \
 	$(LIBCURL) \
 	$(LIBJANSSON)
+
+TESTS = test_plugs.t
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
+test_plugs_t_CPPFLAGS = \
+	-I$(top_srcdir)/src/liblsd \
+	-I$(top_srcdir)/src/libtap
+test_plugs_t_SOURCES = test/plugs.c
+test_plugs_t_LDADD = \
+	$(builddir)/plugs.o \
+	$(top_builddir)/src/libcommon/libcommon.la \
+	$(top_builddir)/src/liblsd/liblsd.la \
+	$(top_builddir)/src/libczmq/libczmq.la \
+	$(top_builddir)/src/libtap/libtap.la

--- a/src/redfishpower/plugs.c
+++ b/src/redfishpower/plugs.c
@@ -1,0 +1,124 @@
+/************************************************************\
+ * Copyright (C) 2024 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "plugs.h"
+
+#include "xmalloc.h"
+#include "czmq.h"
+#include "hostlist.h"
+#include "error.h"
+
+struct plugs {
+    hostlist_t plugs;
+    /* map plug names to plug_data */
+    zhashx_t *plug_map;
+};
+
+static struct plug_data *plug_data_create(const char *plugname,
+                                          const char *hostname)
+{
+    struct plug_data *pd = (struct plug_data *)xmalloc(sizeof(*pd));
+    pd->plugname = xstrdup(plugname);
+    pd->hostname = xstrdup(hostname);
+    return pd;
+}
+
+static void plug_data_destroy(struct plug_data *pd)
+{
+    if (pd) {
+        xfree(pd->plugname);
+        xfree(pd->hostname);
+        xfree(pd);
+    }
+}
+
+/* zhashx_destructor_fn */
+static void plug_data_destroy_wrapper(void **data)
+{
+    struct plug_data *pd = *data;
+    plug_data_destroy(pd);
+}
+
+plugs_t *plugs_create(void)
+{
+    plugs_t *p = (plugs_t *)xmalloc(sizeof(*p));
+
+    if (!(p->plugs = hostlist_create(NULL)))
+        goto cleanup;
+
+    if (!(p->plug_map = zhashx_new()))
+        goto cleanup;
+    zhashx_set_destructor(p->plug_map, plug_data_destroy_wrapper);
+
+    return p;
+
+cleanup:
+    plugs_destroy(p);
+    return NULL;
+}
+
+void plugs_destroy(plugs_t *p)
+{
+    if (p) {
+        hostlist_destroy(p->plugs);
+        zhashx_destroy(&p->plug_map);
+        xfree(p);
+    }
+}
+
+void plugs_add(plugs_t *p, const char *plugname, const char *hostname)
+{
+    struct plug_data *pd;
+    if (hostlist_find(p->plugs, plugname) < 0) {
+        if (hostlist_push(p->plugs, plugname) == 0)
+            err_exit(false, "hostlist_push failed");
+    }
+    pd = plug_data_create(plugname, hostname);
+    zhashx_update(p->plug_map, plugname, pd);
+}
+
+void plugs_remove(plugs_t *p, const char *plugname)
+{
+    zhashx_delete(p->plug_map, plugname);
+    hostlist_delete(p->plugs, plugname);
+}
+
+int plugs_count(plugs_t *p)
+{
+    return hostlist_count(p->plugs);
+}
+
+struct plug_data *plugs_get_data(plugs_t *p, const char *plugname)
+{
+    return zhashx_lookup(p->plug_map, plugname);
+}
+
+hostlist_t *plugs_hostlist(plugs_t *p)
+{
+    return &p->plugs;
+}
+
+int plugs_name_valid(plugs_t *p, const char *plugname)
+{
+    if (hostlist_find(p->plugs, plugname) < 0)
+        return 0;
+    return 1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/redfishpower/plugs.h
+++ b/src/redfishpower/plugs.h
@@ -1,0 +1,43 @@
+/************************************************************\
+ * Copyright (C) 2024 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
+#ifndef REDFISHPOWER_PLUGS_H
+#define REDFISHPOWER_PLUGS_H
+
+#include "hostlist.h"
+
+struct plug_data {
+    char *plugname;
+    char *hostname;
+};
+
+typedef struct plugs plugs_t;
+
+plugs_t *plugs_create(void);
+
+void plugs_destroy(plugs_t *p);
+
+void plugs_add(plugs_t *p, const char *plugname, const char *hostname);
+
+void plugs_remove(plugs_t *p, const char *plugname);
+
+int plugs_count(plugs_t *p);
+
+struct plug_data *plugs_get_data(plugs_t *p, const char *plugname);
+
+hostlist_t *plugs_hostlist(plugs_t *p);
+
+int plugs_name_valid(plugs_t *p, const char *plugname);
+
+#endif /* REDFISHPOWER_PLUGS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -1134,7 +1134,7 @@ int main(int argc, char *argv[])
             err_exit(true, "hostlist_iterator_create");
         while ((hostname = hostlist_next(itr))) {
             if (zhashx_insert(test_power_status, hostname, STATUS_OFF) < 0)
-                err_exit(false, "zhash_insert failure");
+                err_exit(false, "zhashx_insert failure");
             free(hostname);
         }
         hostlist_iterator_destroy(itr);

--- a/src/redfishpower/test/plugs.c
+++ b/src/redfishpower/test/plugs.c
@@ -1,0 +1,108 @@
+/************************************************************\
+ * Copyright (C) 2024 The Regents of the University of California.
+ * (c.f. DISCLAIMER, COPYING)
+ *
+ * This file is part of PowerMan, a remote power management program.
+ * For details, see https://github.com/chaos/powerman.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+\************************************************************/
+
+/*
+ * Test driver for plugs
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tap.h"
+#include "plugs.h"
+
+static void basic_tests(void)
+{
+    plugs_t *p;
+    struct plug_data *pd;
+    hostlist_t *hl;
+    int count;
+
+    p = plugs_create();
+    if (!p)
+        BAIL_OUT("plugs_create");
+
+    count = plugs_count(p);
+    ok(count == 0,
+       "plugs_count returns 0 plugs before we added any");
+
+    plugs_add(p, "blade0", "node0");
+    plugs_add(p, "blade1", "node1");
+
+    count = plugs_count(p);
+    ok(count == 2,
+       "plugs_count returns correct number of plugs");
+
+    ok(plugs_name_valid(p, "blade0") == 1,
+       "plug blade0 is valid");
+    ok(plugs_name_valid(p, "blade1") == 1,
+       "plug blade1 is valid");
+    ok(plugs_name_valid(p, "foof") == 0,
+       "plug foof is not valid");
+
+    hl = plugs_hostlist(p);
+
+    ok(hostlist_count(*hl) == 2,
+       "hostlist contains 2 plugs");
+    ok(hostlist_find(*hl, "blade0") >= 0,
+       "hostlist contains blade0");
+    ok(hostlist_find(*hl, "blade1") >= 0,
+       "hostlist contains blade1");
+
+    pd = plugs_get_data(p, "blade0");
+    ok(pd != NULL,
+       "plugs_get_data returns data for blade0");
+    pd = plugs_get_data(p, "blade0");
+    ok(strcmp(pd->plugname, "blade0") == 0
+       && strcmp(pd->hostname, "node0") == 0,
+       "plugs_get_data returns correct plug");
+
+    pd = plugs_get_data(p, "foof");
+    ok(pd == NULL,
+       "plugs_get_data returns NULL for invalid plug");
+
+    /* remove works */
+
+    plugs_remove(p, "blade1");
+
+    count = plugs_count(p);
+    ok(count == 1,
+       "plugs_count returns correct number of plugs after removal");
+    ok(plugs_name_valid(p, "blade0") == 1,
+       "plug blade0 is valid");
+    ok(plugs_name_valid(p, "blade1") == 0,
+       "plug blade1 is not valid");
+
+    /* overwrite works */
+
+    plugs_add(p, "blade0", "nodeX");
+
+    ok(hostlist_count(*hl) == 1,
+       "hostlist contains 1 plugs");
+
+    ok(plugs_name_valid(p, "blade0") == 1,
+       "plug blade0 is valid");
+
+    pd = plugs_get_data(p, "blade0");
+    ok(strcmp(pd->hostname, "nodeX") == 0,
+       "plugs_get_data returns correct overwrite host");
+
+    plugs_destroy(p);
+}
+
+int main(int argc, char *argv[])
+{
+    plan(NO_PLAN);
+
+    basic_tests();
+
+    done_testing();
+}


### PR DESCRIPTION
Problem: Redfishpower was originally written with only "hosts" in mind, however the correct terminology is for powerman devices
to operate with "plugs".  In most cases, redfishpower "hosts" are simply the same names as the "plugs".

Internally refactor everything to operate on "plugs".  This refactor includes:

- adding a global "plugs" that holds all plugs
- adding a global "plug_map" that maps plugs to hostnames
- initially define all "plugs" to be the same name as the hostnames
- map plug names to hostnames via a new plug2host() function
- all output is based on plugnames instead of hostnames
- rename all functions and variables (e.g. stat_cmd_host() is now stat_cmd_plug()).

----

This PR now precedes #157 