### PR TITLE
redfishpower: add more details on hierarchy errors

### DIFF
--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -651,8 +651,16 @@ static void process_waiters(CURLM *mh,
                     else if (strcmp(pm->cmd, CMD_OFF) == 0
                              && strcmp(status_str, STATUS_OFF) == 0)
                         printf("%s: %s\n", pm->plugname, "ok");
-                    else
-                        printf("%s: ancestor %s\n", pm->plugname, status_str);
+                    else {
+                        struct plug_data *pd = plugs_get_data(plugs, ancestor);
+                        printf("%s: cannot perform %s, dependency %s"
+                               " (host=%s plug=%s)\n",
+                               pm->plugname,
+                               pm->cmd,
+                               status_str,
+                               pd->hostname,
+                               pd->plugname);
+                    }
                 }
 
                 /* this power op is now done */

--- a/t/t0034-redfishpower.t
+++ b/t/t0034-redfishpower.t
@@ -336,7 +336,7 @@ test_expect_success 'powerman -1 t[1-15] completes' '
 	echo Command completed successfully >test_parents2L_on1.exp &&
 	test_cmp test_parents2L_on1.exp test_parents2L_on1.out &&
 	$powerman -h $testaddr -T -1 t[1-15] >test_parents2L_on1T.out &&
-	grep "ancestor off" test_parents2L_on1T.out
+	grep "cannot perform on, dependency off" test_parents2L_on1T.out
 '
 test_expect_success 'powerman -q shows all off still' '
 	$powerman -h $testaddr -q >test_parents2L_query2.out &&
@@ -471,14 +471,14 @@ test_expect_success 'powerman -1 t[1-3] completes but doesnt work' '
 	echo Command completed successfully >test_parents3L_on1.exp &&
 	test_cmp test_parents3L_on1.exp test_parents3L_on1.out &&
 	$powerman -h $testaddr -T -1 t[1-3] >test_parents3L_on1T.out &&
-	grep "ancestor off" test_parents3L_on1T.out
+	grep "cannot perform on, dependency off" test_parents3L_on1T.out
 '
 test_expect_success 'powerman -1 t[4-15] completes but doesnt work' '
 	$powerman -h $testaddr -1 t[4-15] >test_parents3L_on2.out &&
 	echo Command completed successfully >test_parents3L_on2.exp &&
 	test_cmp test_parents3L_on2.exp test_parents3L_on2.out &&
 	$powerman -h $testaddr -T -1 t[4-15] >test_parents3L_on2T.out &&
-	grep "ancestor off" test_parents3L_on2T.out
+	grep "cannot perform on, dependency off" test_parents3L_on2T.out
 '
 test_expect_success 'powerman -q shows all off still' '
 	$powerman -h $testaddr -q >test_parents3L_query2.out &&
@@ -665,7 +665,7 @@ test_expect_success 'powerman -1 t[12-15] completes' '
 	echo Command completed successfully >test_parents3Lbad_on2.exp &&
 	test_cmp test_parents3Lbad_on2.exp test_parents3Lbad_on2.out &&
 	$powerman -h $testaddr -T -1 t[12-15] >test_parents3Lbad_on2T.out &&
-	grep "Node12" test_parents3Lbad_on2T.out | grep "ancestor error"
+	grep "Node12" test_parents3Lbad_on2T.out | grep "cannot perform on, dependency error"
 '
 test_expect_success 'powerman -q shows t[0-2,4-11] on, t3 and children unknown' '
 	$powerman -h $testaddr -q >test_parents3Lbad_query3.out &&


### PR DESCRIPTION
Problem: When a power operation cannot be done due to an issue with the hierarchy, a very general "ancestor off" or "ancestor error" is returned.  This does not provide alot of detail to users.

Update the error message to be of the form

cannot perform <op>, dependency <issue> (host=<host>, plug=<plug>)

for example

cannot perform on, dependency off (host=cmm plug=Enclosure)

Update tests for new error message.

Fixes #153