### PR TITLE
etd/devices: set default Cray EX authentication

### DIFF
--- a/etc/devices/redfishpower-cray-ex-rabbit.dev
+++ b/etc/devices/redfishpower-cray-ex-rabbit.dev
@@ -2,8 +2,9 @@
 # storage hardware. Refer to cray-ex for info specific to that
 # chassis.
 #
-# - Set your system's username/password in the login section of
-#   each specification below.
+# - If necessary, set your system's username/password in the login
+#   section of each specification below.  By default, a manufacturer
+#   default is set below.
 #
 # - Assuming all blades are populated with nodes, switch slots 0-3 are
 #   populated with switches, and switch slots 4 & 7 are populated by a
@@ -72,7 +73,7 @@ specification "cray-ex-rabbit" {
 
 	script login {
 		expect "redfishpower> "
-		send "auth USER:PASS\n"
+		send "auth operator:initial0_op\n"
 		expect "redfishpower> "
 		send "setheader Content-Type:application/json\n"
 		expect "redfishpower> "

--- a/etc/devices/redfishpower-cray-ex.dev
+++ b/etc/devices/redfishpower-cray-ex.dev
@@ -6,8 +6,9 @@
 # section "UPDATING REDFISHPOWER DEVICE FILES" in redfishpower(8) for
 # additional tips.
 #
-# - Set your system's username/password in the login section of
-#   each specification below.
+# - If necessary, set your system's username/password in the login
+#   section of each specification below.  By default, a manufacturer
+#   default is set below.
 #
 # - Assuming all blades are populated with nodes and all switches are
 #   populated, configure in Powerman like below.
@@ -69,7 +70,7 @@ specification "cray-ex" {
 
 	script login {
 		expect "redfishpower> "
-		send "auth USER:PASS\n"
+		send "auth operator:initial0_op\n"
 		expect "redfishpower> "
 		send "setheader Content-Type:application/json\n"
 		expect "redfishpower> "


### PR DESCRIPTION
Problem: The default authentication set by the manufactuer is known for Cray EX chassis.  Setting the default would make initial testing with powerman easier for users.

Set the manufacturer default authentication in redfishpower-cray-ex.dev and redfishpower-cray-ex-rabbit.dev.

Fixes #176