### PR TITLE
configure.ac: build helper executables by default

### DIFF
--- a/config/ac_httppower.m4
+++ b/config/ac_httppower.m4
@@ -1,5 +1,5 @@
 #
-# Add --with-httppower configure option (no by default).
+# Add --without-httppower configure option (build by default).
 # If yes, not finding curl header file or lib is fatal.
 # Define HAVE_CURL_CURL_H=1, and HAVE_LIBCURL=1 in config.h.
 # Substitute LIBCURL with -lcurl and define WITH_HTTPPOWER=1 in Makefiles.
@@ -8,13 +8,15 @@
 AC_DEFUN([AC_HTTPPOWER],
 [
   AC_ARG_WITH([httppower],
-    AS_HELP_STRING([--with-httppower], [Build httppower executable]))
+    AS_HELP_STRING([--without-httppower], [Do not build httppower executable]),
+    [],
+    [with_httppower=yes])
   AS_IF([test "x$with_httppower" = "xyes"], [
     AC_CHECK_HEADERS([curl/curl.h])
     X_AC_CHECK_COND_LIB([curl], [curl_easy_setopt])
   ])
   AS_IF([test "x$with_httppower" = "xyes" && test "x$ac_cv_header_curl_curl_h" = "xno" -o "x$ac_cv_lib_curl_curl_easy_setopt" = "xno"], [
-    AC_MSG_ERROR([could not find curl library])
+    AC_MSG_ERROR([could not find curl library for httppower])
   ])
   AM_CONDITIONAL(WITH_HTTPPOWER, [test "x$with_httppower" = "xyes"])
 ])

--- a/config/ac_redfishpower.m4
+++ b/config/ac_redfishpower.m4
@@ -1,11 +1,13 @@
 #
-# Add --with-redfishpower configure option (no by default).
+# Add --without-redfishpower configure option (build by default).
 # If yes, not finding curl or jansson is fatal.
 #
 AC_DEFUN([AC_REDFISHPOWER],
 [
   AC_ARG_WITH([redfishpower],
-    AS_HELP_STRING([--with-redfishpower], [Build redfishpower executable]))
+    AS_HELP_STRING([--without-redfishpower], [Do not build redfishpower executable]),
+    [],
+    [with_redfishpower=yes])
   AS_IF([test "x$with_redfishpower" = "xyes"], [
     AC_CHECK_HEADERS([curl/curl.h])
     X_AC_CHECK_COND_LIB([curl], [curl_multi_perform])
@@ -15,12 +17,12 @@ AC_DEFUN([AC_REDFISHPOWER],
   AS_IF([test "x$with_redfishpower" = "xyes" \
               && test "x$ac_cv_header_curl_curl_h" = "xno" \
                  -o "x$ac_cv_lib_curl_curl_multi_perform" = "xno"], [
-    AC_MSG_ERROR([could not find curl library])
+    AC_MSG_ERROR([could not find curl library for redfishpower])
   ])
   AS_IF([test "x$with_redfishpower" = "xyes" \
               && test "x$ac_cv_header_jansson_h" = "xno" \
                  -o "x$ac_cv_lib_curl_json_object_set" = "xno"], [
-    AC_MSG_ERROR([could not find jansson library])
+    AC_MSG_ERROR([could not find jansson library for redfishpower])
   ])
   AM_CONDITIONAL(WITH_REDFISHPOWER, [test "x$with_redfishpower" = "xyes"])
 ])

--- a/config/ac_snmppower.m4
+++ b/config/ac_snmppower.m4
@@ -1,5 +1,5 @@
 #
-# Add --with-snmppower configure option (no by default).
+# Add --without-snmppower configure option (build by default).
 # If yes, not finding netsnmp header file or lib is fatal.
 # Define HAVE_NET_SNMP_NET_SNMP_CONFIG_H=1 and HAVE_LIBSNMP=1 in config.h.
 # Substitute LIBSNMP with -lsnmp and define WITH_SNMPPOWER=1 in Makefiles.
@@ -8,13 +8,15 @@
 AC_DEFUN([AC_SNMPPOWER],
 [
   AC_ARG_WITH([snmppower],
-    AS_HELP_STRING([--with-snmppower], [Build snmppower executable]))
+    AS_HELP_STRING([--without-snmppower], [Do not build snmppower executable]),
+    [],
+    [with_snmppower=yes])
   AS_IF([test "x$with_snmppower" = "xyes"], [
     AC_CHECK_HEADERS([net-snmp/net-snmp-config.h])
     X_AC_CHECK_COND_LIB([netsnmp], [init_snmp])
   ])
   AS_IF([test "x$with_snmppower" = "xyes" && test "x$ac_cv_header_net_snmp_net_snmp_config_h" = "xno" -o "x$ac_cv_lib_snmp_init_snmp" = "xno"], [
-    AC_MSG_ERROR([could not find snmp library])
+    AC_MSG_ERROR([could not find snmp library for snmppower])
   ])
   AM_CONDITIONAL(WITH_SNMPPOWER, [test "x$with_snmppower" = "xyes"])
 ])


### PR DESCRIPTION
Problem: Some tests now require the helper redfishpower executable. This executable is not built by default, possibly breaking tests.

Build helper executables httppower, snmppower, and redfishpower by default.  Configure options to disable the builds are available.

Fixes #178