### PR TITLE
redfishpower: support auth setup on command line

### DIFF
--- a/etc/devices/redfishpower-cray-ex-rabbit.dev
+++ b/etc/devices/redfishpower-cray-ex-rabbit.dev
@@ -2,9 +2,8 @@
 # storage hardware. Refer to cray-ex for info specific to that
 # chassis.
 #
-# - If necessary, set your system's username/password in the login
-#   section of each specification below.  By default, a manufacturer
-#   default is set below.
+# - If necessary, set your system's username/password via redfishpower's
+#   --auth option.
 #
 # - Assuming all blades are populated with nodes, switch slots 0-3 are
 #   populated with switches, and switch slots 4 & 7 are populated by a

--- a/etc/devices/redfishpower-cray-ex.dev
+++ b/etc/devices/redfishpower-cray-ex.dev
@@ -6,9 +6,8 @@
 # section "UPDATING REDFISHPOWER DEVICE FILES" in redfishpower(8) for
 # additional tips.
 #
-# - If necessary, set your system's username/password in the login
-#   section of each specification below.  By default, a manufacturer
-#   default is set below.
+# - If necessary, set your system's username/password via redfishpower's
+#   --auth option.
 #
 # - Assuming all blades are populated with nodes and all switches are
 #   populated, configure in Powerman like below.

--- a/etc/devices/redfishpower-cray-r272z30.dev
+++ b/etc/devices/redfishpower-cray-r272z30.dev
@@ -6,7 +6,8 @@
 #   node "node1" "redfishpower" "pnode1"
 #   node "node2" "redfishpower" "pnode2"
 #
-# - Set your system's username/password in the login section below
+# - If necessary, set your system's username/password via redfishpower's
+#   --auth option.
 #
 # - This device specification was tested on a Cray with Gigabyte R272-Z30.
 #

--- a/etc/devices/redfishpower-cray-windom.dev
+++ b/etc/devices/redfishpower-cray-windom.dev
@@ -9,7 +9,8 @@
 #   node "node3" "redfishpower0" "pnode3"
 #   node "node4" "redfishpower1" "pnode4"
 #
-# - Set your system's username/password in the login section below
+# - If necessary, set your system's username/password via redfishpower's
+#   --auth option.
 #
 # - This device specification was tested on a Cray Windom.
 #

--- a/etc/devices/redfishpower-supermicro.dev
+++ b/etc/devices/redfishpower-supermicro.dev
@@ -6,7 +6,8 @@
 #   node "node1" "redfishpower" "pnode1"
 #   node "node2" "redfishpower" "pnode2"
 #
-# - Set your system's username/password in the login section below
+# - If necessary, set your system's username/password via redfishpower's
+#   --auth option.
 #
 # - This device specification was tested on a Supermicro H12DSG-O-CPU.
 #

--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -23,6 +23,11 @@ system call.
 .I "-H, --header string"
 Set extra HEADER to use.  Typically is Content-Type:application/json.
 .TP
+.I "-A, --auth user:pass"
+Authenticate with the specified user and password, specified in the
+form "user:pass".  If specified on the command line, it cannot be set
+at the prompt with the "auth" command.
+.TP
 .I "-S, --statpath string"
 Set Redfish path for obtaining power status.  Typically is redfish/v1/Systems/1.
 .TP


### PR DESCRIPTION
Problem: It can be inconvenient to configure username/password authentication info with redfishpower, since it can only be done in the device files.

Support a --auth option to configure it on the command line.  This way it can be configured in powerman config files.

Fixes #94
