### PR TITLE
redfishpower: support message timeout config

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -43,6 +43,15 @@ Set default Redfish postdata for performing power on.  Typically is {"ResetType"
 .I "-G, --offpostdata string"
 Set default Redfish postdata for performing power off.  Typically is {"ResetType":"ForceOff"}
 .TP
+.I "-m, --message-timeout seconds"
+Set message timeout, the timeout most notably associated with
+connection timeouts or name resolution timeouts.  Default is 5
+seconds.  Note that this different than the command timeout specified
+by
+.B settimeout
+below.  The latter is the total command timeout, which may involve
+multiple messages and a polling of power status.
+.TP
 .I "-v, --verbose"
 Increase output verbosity.  Can be specified multiple times.
 .SH INTERACTIVE COMMANDS

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -1230,7 +1230,7 @@ static int setup_plug(const char *plugname,
     int hostindex;
 
     errno = 0;
-    hostindex = strtol (hostindexstr, &endptr, 10);
+    hostindex = strtol(hostindexstr, &endptr, 10);
     if (errno
         || endptr[0] != '\0'
         || hostindex < 0) {
@@ -1372,7 +1372,7 @@ static void settimeout(char **av)
         long tmp;
 
         errno = 0;
-        tmp = strtol (av[0], &endptr, 10);
+        tmp = strtol(av[0], &endptr, 10);
         if (errno
             || endptr[0] != '\0'
             || tmp <= 0)

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -67,7 +67,7 @@ static hostlist_t test_fail_power_cmd_hosts;
 static zhashx_t *test_power_status;
 
 /* in seconds */
-#define MESSAGE_TIMEOUT            10
+#define MESSAGE_TIMEOUT            5
 #define CMD_TIMEOUT_DEFAULT        60
 
 /* Per documentation, wait incremental time then proceed if timeout < 0 */
@@ -268,6 +268,8 @@ static void powermsg_init_curl(struct powermsg *pm)
     if ((pm->eh = curl_easy_init()) == NULL)
         err_exit(false, "curl_easy_init failed");
 
+    /* Per documentation, CURLOPT_TIMEOUT overrides
+     * CURLOPT_CONNECTTIMEOUT */
     Curl_easy_setopt((pm->eh, CURLOPT_TIMEOUT, MESSAGE_TIMEOUT));
     Curl_easy_setopt((pm->eh, CURLOPT_FAILONERROR, 1));
 

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -1868,6 +1868,12 @@ int main(int argc, char *argv[])
          * lets put it to a millisecond.
          */
         status_polling_interval = 1000;
+
+        /* output settings of command line options that can't be tested in test mode */
+        if (header)
+            fprintf(stderr, "command line option: header = %s\n", header);
+        if (userpwd)
+            fprintf(stderr, "command line option: auth = %s\n", userpwd);
     }
 
     shell(mh);

--- a/t/t0034-redfishpower.t
+++ b/t/t0034-redfishpower.t
@@ -691,6 +691,10 @@ test_expect_success 'auth option setting appears to work' '
 	echo "quit" | $redfishdir/redfishpower -h t[0-15] --test-mode --auth="foo:bar" 2> auth.err
 	grep "auth = foo:bar" auth.err
 '
+test_expect_success 'message timeout option setting appears to work' '
+	echo "quit" | $redfishdir/redfishpower -h t[0-15] --test-mode --message-timeout=33 2> message_timeout.err
+	grep "message timeout = 33" message_timeout.err
+'
 
 #
 # valgrind

--- a/t/t0034-redfishpower.t
+++ b/t/t0034-redfishpower.t
@@ -678,6 +678,21 @@ test_expect_success 'stop powerman daemon (parents3Lbad)' '
 '
 
 #
+# options
+#
+# libcurl specific and not testable under test-mode, so we just check the options work
+#
+
+test_expect_success 'header option setting appears to work' '
+	echo "quit" | $redfishdir/redfishpower -h t[0-15] --test-mode --header="my content header" 2> header.err
+	grep "header = my content header" header.err
+'
+test_expect_success 'auth option setting appears to work' '
+	echo "quit" | $redfishdir/redfishpower -h t[0-15] --test-mode --auth="foo:bar" 2> auth.err
+	grep "auth = foo:bar" auth.err
+'
+
+#
 # valgrind
 #
 


### PR DESCRIPTION
Problem: The message timeout is currently hard coded to 5 seconds, which may be too short or long on some systems.

Support a new --message-timeout option to support configuration of the message timeout.