### PR TITLE
redfishpower: support new --resolve-hosts option

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -52,6 +52,11 @@ by
 below.  The latter is the total command timeout, which may involve
 multiple messages and a polling of power status.
 .TP
+.I "-o, --resolve-hosts"
+Resolve host and pass IP address to libcurl instead of hostname.  This
+works around a DNS race in libcurl versions less than 7.66.  Users
+hitting the DNS race may see "Timeout was reached" errors.
+.TP
 .I "-v, --verbose"
 Increase output verbosity.  Can be specified multiple times.
 .SH INTERACTIVE COMMANDS

--- a/t/t0034-redfishpower.t
+++ b/t/t0034-redfishpower.t
@@ -695,6 +695,10 @@ test_expect_success 'message timeout option setting appears to work' '
 	echo "quit" | $redfishdir/redfishpower -h t[0-15] --test-mode --message-timeout=33 2> message_timeout.err
 	grep "message timeout = 33" message_timeout.err
 '
+test_expect_success 'resolve-hosts option setting appears to work' '
+	echo "quit" | $redfishdir/redfishpower -h t[0-15] --test-mode --resolve-hosts 2> resolve_hosts.err
+	grep "resolve-hosts = set" resolve_hosts.err
+'
 
 #
 # valgrind


### PR DESCRIPTION
Problem: A DNS race in libcurl exists in versions before 7.66.  This can
lead to redfishpower returning "Timeout was reached".

Support a new --host2ip option which will convert input hostnames to IP
addresses and pass those IP addresses to libcurl.  This appears to work
around the race.

----

Built on top of #186 ... maybe `--host2ip` option name could be better?
