### PR TITLE
redfishpower: increase default message timeout

### DIFF
--- a/man/redfishpower.8.in
+++ b/man/redfishpower.8.in
@@ -45,7 +45,7 @@ Set default Redfish postdata for performing power off.  Typically is {"ResetType
 .TP
 .I "-m, --message-timeout seconds"
 Set message timeout, the timeout most notably associated with
-connection timeouts or name resolution timeouts.  Default is 5
+connection timeouts or name resolution timeouts.  Default is 10
 seconds.  Note that this different than the command timeout specified
 by
 .B settimeout

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -74,7 +74,7 @@ static zhashx_t *test_power_status;
 static zhashx_t *resolve_hosts_cache = NULL;
 
 /* in seconds */
-#define MESSAGE_TIMEOUT_DEFAULT    5
+#define MESSAGE_TIMEOUT_DEFAULT    10
 #define CMD_TIMEOUT_DEFAULT        60
 
 /* Per documentation, wait incremental time then proceed if timeout < 0 */


### PR DESCRIPTION
Problem: In commit

97449c5f8700990293c0048d6f4b437097102921

the default message timeout was lowered from 10 seconds to 5 seconds. While this is good for the "99%" of cases, it doesn't appear to be good for "99.9% of cases, as some timeouts appear a little more often.

Change the default message timeout back to 10 seconds.