### PR TITLE
powerman: increase maximum line length

### DIFF
--- a/src/powerman/client_proto.h
+++ b/src/powerman/client_proto.h
@@ -21,7 +21,7 @@
  * If not quit, goto 3
  */
 
-#define CP_LINEMAX  8192                /* max request/response line length */
+#define CP_LINEMAX  131072              /* max request/response line length */
 #define CP_EOL      "\r\n"              /* line terminator */
 #define CP_PROMPT   "powerman> "        /* prompt */
 #define CP_VERSION  "001 %s" CP_EOL

--- a/t/t0039-llnl-el-capitan-cluster.t
+++ b/t/t0039-llnl-el-capitan-cluster.t
@@ -106,6 +106,12 @@ test_expect_success 'powerman -q shows all off' '
 	makeoutput "" "$ALLSTR" "" >query5.exp &&
 	test_cmp query5.exp query5.out
 '
+test_expect_success 'powerman -q works with giant input' '
+	nodes=$(echo elcap\[$(seq -s, 0 2 16382)\]) &&
+	$powerman -h $testaddr -q $nodes >query6.out &&
+	makeoutput "" "$nodes" "" >query6.exp &&
+	test_cmp query6.exp query6.out
+'
 test_expect_success 'stop powerman daemon' '
 	kill -15 $(cat powermand.pid) &&
 	wait


### PR DESCRIPTION
Problem: On very larger clusters command line operations of a large
number of nodes (e.g. node[1,3,5,...,4997,4999]) can exceed internal
buffers, leading to errors.

Increase the internal maximum line length from 8K to 128K, which should
handle any HPC cluster in existence today and larger ones in the future.

Fixes #193

---

side note, for the test I just created the giant input and put it in a file in `t/data` b/c I was not confident that hostlist generating tools that could generate it would exist on many environments. (i.e. reproducer I was shown used `cluset` which I don't think is that common.  Neither would `flux hostlist`, etc.)