### PR TITLE
powerman: correct potential segfault

### DIFF
--- a/src/powerman/device.c
+++ b/src/powerman/device.c
@@ -1178,7 +1178,7 @@ static bool _process_setresult(Device *dev, Action *act, ExecCtx *e)
                 arg->val = xstrdup(str);
             }
 
-            if (result != RT_SUCCESS) {
+            if (arg && result != RT_SUCCESS) {
                 char strbuf[1024];
                 snprintf(strbuf, sizeof(strbuf), "%s", arg->val);
                 /* remove trailing carriage return or newline */

--- a/src/powerman/device.c
+++ b/src/powerman/device.c
@@ -88,7 +88,7 @@ typedef struct {
  */
 #define MAX_LEVELS 2
 typedef struct {
-    int com;                    /* one of the PM_* above */
+    int com;                    /* one of the PM_* script types */
     List exec;                  /* stack of ExecCtxs (outer block is first) */
     ActionCB complete_fun;      /* callback for action completion */
     VerbosePrintf vpf_fun;      /* callback for device telemetry */


### PR DESCRIPTION
Problem: In _process_setresult() if the plug name is not found in the inputted arglist, it can result in a segfault.  This can occur when power operations on dependent targets (e.g. the parent of node needs to be powered on) have errors, leading to an unexpected host having a "power result".

Check that arg is non-NULL before trying to dereference it.

Fixes #197

---

side note, alternately those types of unexpected error messages could be removed from `redfishpower`.  I elected to leave those error messages.  I figure for telemetry output and debugging, it can still be useful to output "severe error messages" (i.e. http error) on parents

