### PR TITLE
redfishpower: remove excessive debug output

### DIFF
--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -2002,8 +2002,8 @@ int main(int argc, char *argv[])
             fprintf(stderr, "command line option: auth = %s\n", userpwd);
         if (message_timeout != MESSAGE_TIMEOUT_DEFAULT)
             fprintf(stderr, "command line option: message timeout = %ld\n", message_timeout);
-        fprintf(stderr, "command line option: resolve-hosts = %s\n",
-                resolve_hosts ? "set" : "not set");
+        if (resolve_hosts)
+            fprintf(stderr, "command line option: resolve-hosts set\n");
     }
 
     shell(mh);

--- a/t/t0034-redfishpower.t
+++ b/t/t0034-redfishpower.t
@@ -697,7 +697,7 @@ test_expect_success 'message timeout option setting appears to work' '
 '
 test_expect_success 'resolve-hosts option setting appears to work' '
 	echo "quit" | $redfishdir/redfishpower -h t[0-15] --test-mode --resolve-hosts 2> resolve_hosts.err
-	grep "resolve-hosts = set" resolve_hosts.err
+	grep "resolve-hosts set" resolve_hosts.err
 '
 
 #


### PR DESCRIPTION
Problem: In test mode, debug for the resolve-hosts option is always output.  This can get annoying.

Only output debug indicating that resolve-hosts is set.  Don't output if it is not set.

Fixes #207