### PR TITLE
systemd: drop deprecated After=syslog.target

### DIFF
--- a/etc/powerman.service.in
+++ b/etc/powerman.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=PowerMan
-After=syslog.target network.target
+After=network.target
 
 [Service]
 Environment=SHELL=/bin/sh


### PR DESCRIPTION
Problem: this syslog target is deprecated.

Syslog is socket-activated so there is no need to wait for it.

Fixes #203