### PR TITLE
testsuite: skip huge test unless requested

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
            --with-tcp-wrappers
     - name: make
       run: make
-    - name: make check
+    - name: GITHUB_CI=t make check
       run: make check
     - name: make distcheck
       run: DISTCHECK_CONFIGURE_FLAGS=--with-redfishpower make distcheck

--- a/t/t0039-llnl-el-capitan-cluster.t
+++ b/t/t0039-llnl-el-capitan-cluster.t
@@ -4,6 +4,12 @@ test_description='Check LLNL El Capitan config'
 
 . `dirname $0`/sharness.sh
 
+# Setting the --long option or TEST_LONG=t fulfills the EXPENSIVE prereq
+if ! test_have_prereq EXPENSIVE && ! test -n "$GITHUB_CI"; then
+	skip_all='skipping large scale El Capitan test'
+	test_done
+fi
+
 ulimit -n 2048
 
 powermand=$SHARNESS_BUILD_DIRECTORY/src/powerman/powermand


### PR DESCRIPTION
Problem: the debian riscv64 build environment is failing on the el capitan scaling test.

We don't have detailed test output to diagnose the failure but we can probably assume that this is a fairly under-powered builder.

Disable the test unless TEST_LONG is set in the test environment. Set TEST_LONG when the github workflow runs make check, so we won't lose this coverage in github CI.

Fixes #206