### PR TITLE
httppower|redfishpower: Curl_easy_setopt() Expects long int

### DIFF
--- a/src/httppower/httppower.c
+++ b/src/httppower/httppower.c
@@ -88,7 +88,7 @@ void post(CURL *h, char **av)
     }
 
     if (postdata && url_ptr) {
-        curl_easy_setopt(h, CURLOPT_POST, 1);
+        curl_easy_setopt(h, CURLOPT_POST, 1L);
         curl_easy_setopt(h, CURLOPT_URL, url_ptr);
         curl_easy_setopt(h, CURLOPT_POSTFIELDS, postdata);
         curl_easy_setopt(h, CURLOPT_POSTFIELDSIZE, strlen (postdata));
@@ -96,7 +96,7 @@ void post(CURL *h, char **av)
             printf("Error: %s\n", errbuf);
         curl_easy_setopt(h, CURLOPT_URL, "");
         curl_easy_setopt(h, CURLOPT_POSTFIELDS, "");
-        curl_easy_setopt(h, CURLOPT_POSTFIELDSIZE, 0);
+        curl_easy_setopt(h, CURLOPT_POSTFIELDSIZE, 0L);
     } else
         printf("Nothing to post!\n");
 
@@ -137,7 +137,7 @@ void put(CURL *h, char **av)
     }
 
     if (putdata && url_ptr) {
-        curl_easy_setopt(h, CURLOPT_UPLOAD, 1);
+        curl_easy_setopt(h, CURLOPT_UPLOAD, 1L);
         curl_easy_setopt(h, CURLOPT_URL, url_ptr);
         curl_easy_setopt(h, CURLOPT_READFUNCTION, put_read_cb);
         pcd.data = putdata;
@@ -147,7 +147,7 @@ void put(CURL *h, char **av)
         if (curl_easy_perform(h) != 0)
             printf("Error: %s\n", errbuf);
         curl_easy_setopt(h, CURLOPT_URL, "");
-        curl_easy_setopt(h, CURLOPT_UPLOAD, 0);
+        curl_easy_setopt(h, CURLOPT_UPLOAD, 0L);
     } else
         printf("Nothing to put!\n");
 
@@ -162,7 +162,7 @@ void get(CURL *h, char **av)
     char *myurl = _make_url(av[0]);
 
     if (myurl) {
-        curl_easy_setopt(h, CURLOPT_HTTPGET, 1);
+        curl_easy_setopt(h, CURLOPT_HTTPGET, 1L);
         curl_easy_setopt(h, CURLOPT_URL, myurl);
         if (curl_easy_perform(h) != 0)
             printf("Error: %s\n", errbuf);
@@ -324,9 +324,9 @@ main(int argc, char *argv[])
     if ((h = curl_easy_init()) == NULL)
         err_exit(false, "curl_easy_init failed");
 
-    curl_easy_setopt(h, CURLOPT_TIMEOUT, 5);
+    curl_easy_setopt(h, CURLOPT_TIMEOUT, 5L);
     curl_easy_setopt(h, CURLOPT_ERRORBUFFER, errbuf);
-    curl_easy_setopt(h, CURLOPT_FAILONERROR, 1);
+    curl_easy_setopt(h, CURLOPT_FAILONERROR, 1L);
 
     /* for time being */
     curl_easy_setopt(h, CURLOPT_SSL_VERIFYPEER, 0L);

--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -288,7 +288,7 @@ static void powermsg_init_curl(struct powermsg *pm)
     /* Per documentation, CURLOPT_TIMEOUT overrides
      * CURLOPT_CONNECTTIMEOUT */
     Curl_easy_setopt((pm->eh, CURLOPT_TIMEOUT, message_timeout));
-    Curl_easy_setopt((pm->eh, CURLOPT_FAILONERROR, 1));
+    Curl_easy_setopt((pm->eh, CURLOPT_FAILONERROR, 1L));
 
     /* for time being */
     Curl_easy_setopt((pm->eh, CURLOPT_SSL_VERIFYPEER, 0L));
@@ -321,12 +321,12 @@ static void powermsg_init_curl(struct powermsg *pm)
     Curl_easy_setopt((pm->eh, CURLOPT_URL, pm->url));
 
     if (pm->postdata) {
-        Curl_easy_setopt((pm->eh, CURLOPT_POST, 1));
+        Curl_easy_setopt((pm->eh, CURLOPT_POST, 1L));
         Curl_easy_setopt((pm->eh, CURLOPT_POSTFIELDS, pm->postdata));
         Curl_easy_setopt((pm->eh, CURLOPT_POSTFIELDSIZE, strlen(pm->postdata)));
     }
     else
-        Curl_easy_setopt((pm->eh, CURLOPT_HTTPGET, 1));
+        Curl_easy_setopt((pm->eh, CURLOPT_HTTPGET, 1L));
 }
 
 static char *resolve_hosts_url(const char *hostname, const char *path)
@@ -1221,7 +1221,7 @@ static void power_cleanup(struct powermsg *pm)
 {
     if (!test_mode && pm->eh) {
         Curl_easy_setopt((pm->eh, CURLOPT_POSTFIELDS, ""));
-        Curl_easy_setopt((pm->eh, CURLOPT_POSTFIELDSIZE, 0));
+        Curl_easy_setopt((pm->eh, CURLOPT_POSTFIELDSIZE, 0L));
     }
     powermsg_destroy(pm);
 }


### PR DESCRIPTION
Recent curl versions require its option values to be passed as long.

Issue was raised in https://bugs.debian.org/1107411