### PR TITLE
Fix function prototypes with empty parameter lists

### DIFF
--- a/src/powerman/parse_lex.l
+++ b/src/powerman/parse_lex.l
@@ -27,7 +27,7 @@ extern YYSTYPE yylval;
 #include "xmalloc.h"
 #include "error.h"
 #include "parse_util.h"
-extern void yyerror();
+extern void yyerror(const char *);
 
 #define YY_NO_INPUT /* silence compiler warnings about unused input() */
 #define MAX_INCLUDE_DEPTH 10
@@ -109,7 +109,7 @@ static List line_ptrs;
         *string_buf_ptr++ = '\v';
     }
     "\n" {
-        yyerror();
+        yyerror(NULL);
     }
     \\[0-9][0-9][0-9] {
         *string_buf_ptr++ = strtol(&yytext[1], NULL, 8);

--- a/src/powerman/parse_tab.y
+++ b/src/powerman/parse_tab.y
@@ -101,8 +101,8 @@ static long _strtolong(char *str);
 static double _strtodouble(char *str);
 static void _doubletotv(struct timeval *tv, double val);
 
-extern int yylex();
-void yyerror();
+extern int yylex(void);
+void yyerror(const char *msg);
 
 
 static List device_specs = NULL;      /* list of Spec's */
@@ -836,7 +836,7 @@ static void _warnmsg(char *msg)
     err(false, "warning: %s: %s::%d", msg, scanner_file(), scanner_line());
 }
 
-void yyerror()
+void yyerror(const char *msg)
 {
     _errormsg("parse error");
 }


### PR DESCRIPTION
Pre-ANSI function declarators which do not declare their parameters have been removed in C23 and the syntax reused for declaring functions with no parameters (like C++).  GCC 15 defaults to C23, so these declarators may cause compilation failures.  For example:

	parse_tab.c: In function 'yyparse':
	parse_tab.c:2117:7: error: too many arguments to function 'yyerror'; expected 0, have 1
	 2117 |       yyerror (YY_("syntax error"));
	      |       ^~~~~~~
	parse_tab.y:105:6: note: declared here
	  105 | void yyerror();
	      |      ^~~~~~~
	parse_tab.c:2228:3: error: too many arguments to function 'yyerror'; expected 0, have 1
	 2228 |   yyerror (YY_("memory exhausted"));
	      |   ^~~~~~~
	parse_tab.y:105:6: note: declared here
	  105 | void yyerror();
	      |      ^~~~~~~

Explicitly specify the parameters of `yyerror` and `yylex`.