### PR TITLE
liblsd: fix const-correctness in _parse_single_range()

### DIFF
--- a/src/liblsd/hostlist.c
+++ b/src/liblsd/hostlist.c
@@ -1400,13 +1400,13 @@ static int _parse_single_range(const char *str, struct _range *range)
     if (!orig)
         seterrno_ret(ENOMEM, 0);
 
-    if ((p = strchr(str, '-'))) {
+    if ((p = strchr(orig, '-'))) {
         *p++ = '\0';
         if (*p == '-')     /* do NOT allow negative numbers */
             goto error;
     }
-    range->lo = strtoul(str, &q, 10);
-    if (q == str)
+    range->lo = strtoul(orig, &q, 10);
+    if (q == orig)
         goto error;
 
     range->hi = (p && *p) ? strtoul(p, &q, 10) : range->lo;
@@ -1423,8 +1423,8 @@ static int _parse_single_range(const char *str, struct _range *range)
         seterrno_ret(ERANGE, 0);
     }
 
+    range->width = strlen(orig);
     free(orig);
-    range->width = strlen(str);
     return 1;
 
   error:


### PR DESCRIPTION
_parse_single_range() accepts a `const char *str` argument and creates a mutable copy via strdup() into `orig`. However, it was incorrectly calling strchr() and strtoul() on the original const pointer `str` rather than on the mutable copy.

This is both a correctness bug and a build failure with modern glibc:
- glibc now provides const-preserving overloads of strchr(), returning `const char *` when passed a `const char *`. Assigning this to `char *p` discards the const qualifier, triggering a compile error with -Werror=discarded-qualifiers.
- The subsequent `*p++ = '\0'` write through `p` would modify memory via a pointer originally derived from a const string.

Fix by using `orig` (the mutable strdup copy) for strchr() and strtoul() calls, which is the correct buffer to mutate.