### PR TITLE
redfishpower: fix const-correctness in calc_path()

### DIFF
--- a/src/redfishpower/redfishpower.c
+++ b/src/redfishpower/redfishpower.c
@@ -193,7 +193,7 @@ void help(void)
 
 static char *calc_path(const char *lpath, const char *plugname)
 {
-    char *ptr;
+    const char *ptr;
 
     /* assumption, at most one {{plug}} in path */
     if ((ptr = strstr(lpath, "{{plug}}"))) {


### PR DESCRIPTION
calc_path() receives lpath as const char * and only reads from the substring located with strstr().

On modern libc/toolchains, strstr() is const-preserving for const inputs. Assigning its result to char * therefore discards qualifiers and may fail with -Werror=discarded-qualifiers.

On latest Ubuntu release, powerman fails to build with following error:

redfishpower.c: In function ‘calc_path’:
redfishpower.c:199:14: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  199 |     if ((ptr = strstr(lpath, "{{plug}}"))) {
