### PR TITLE
mergify: update mergify config for newer defaults

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    batch_size: 1
     queue_conditions:
       - base=master
       - label="merge-when-passing"
@@ -18,6 +19,9 @@ queue_rules:
       - -title~=^\[*[Ww][Ii][Pp]
     update_method: rebase
     merge_method: merge
+
+merge_queue:
+  max_parallel_checks: 1
 
 pull_request_rules:
   - name: rebase and merge when passing all checks


### PR DESCRIPTION
Problem: .mergify has not been updated in awhile and merging does not work with newer defaults set by mergify.

Update configs per mergify documentation.